### PR TITLE
added a space so the bullets would render correctly and fixed what I …

### DIFF
--- a/docs/polaris/queueing-and-running-jobs/job-and-queue-scheduling.md
+++ b/docs/polaris/queueing-and-running-jobs/job-and-queue-scheduling.md
@@ -350,10 +350,11 @@ x3014c0s25b0n0       offline,resv-exclusive Checking on ConnectX-5 firmware
 
 ### Running MPI+OpenMP Applications
 Once a submitted job is running calculations can be launched on the compute nodes using `mpiexec` to start an MPI application. Documentation is accessible via `man mpiexec` and some helpful options follow.
+
 * `-n` total number of MPI ranks
 * `-ppn` number of MPI ranks per node
 * `--cpu-bind` CPU binding for application
-* `--depth` number of cpus per rank (useful with `--cpu-bind depth`)
+* `--depth` number of cpus per rank (useful with `--cpu-bind`)
 * `--env` set environment variables (`--env OMP_NUM_THREADS=2`)
 * `--hostfile` indicate file with hostnames (the default is `--hostfile $PBS_NODEFILE`)
 


### PR DESCRIPTION
…*think* was an error.  I named the branch add bullets, but when I got there I realized they were already there I just needed to add a space between the text and the first bullet so it would render correctly.  However, I in `--depth` in the comment about useful with --cpu-bind I think there was an extra word depth there, but maybe I am wrong, which is why I asked Chris to review.