### PR TITLE
add queue info to examples

### DIFF
--- a/docs/polaris/applications-and-libraries/applications/lammps.md
+++ b/docs/polaris/applications-and-libraries/applications/lammps.md
@@ -71,6 +71,8 @@ An example submission script for running a KOKKOS-enabled LAMMPS executable is b
 #PBS -l select=64:system=polaris
 #PBS -l place=scatter
 #PBS -l walltime=0:15:00
+#PBS -q prod
+#PBS -A Catalyst
 
 export MPICH_GPU_SUPPORT_ENABLED=1
 

--- a/docs/polaris/applications-and-libraries/applications/vasp.md
+++ b/docs/polaris/applications-and-libraries/applications/vasp.md
@@ -119,6 +119,8 @@ make -j1
 #PBS -l select=1:system=polaris
 #PBS -l place=scatter
 #PBS -l walltime=0:15:00
+#PBS -q debug
+#PBS -A Catalyst
 
 module purge
 module add PrgEnv-nvhpc cray-fftw cray-libsci

--- a/docs/polaris/data-science-workflows/containers/containers.md
+++ b/docs/polaris/data-science-workflows/containers/containers.md
@@ -65,7 +65,7 @@ Note that `latest` here mean when these docs were written, summer 2022.  It may 
 
 #### Running the new container
 
-Let's take an interactive node to test the container (`qsub -I -l walltime=1:00:00 -l select=1:system=polaris` for example).
+Let's take an interactive node to test the container (`qsub -I -l walltime=1:00:00 -l select=1:system=polaris -q debug` for example).
 
 When on the interactive node, re-load the modules you need:
 ```bash

--- a/docs/polaris/queueing-and-running-jobs/job-and-queue-scheduling.md
+++ b/docs/polaris/queueing-and-running-jobs/job-and-queue-scheduling.md
@@ -144,8 +144,8 @@ mpiexec --np ${NTOTRANKS} -ppn ${NRANKS} -d ${NDEPTH} -env OMP_NUM_THREADS=${NTH
 
 ### qsub examples ###
 
-* `qsub -A my_allocation -l select=4:system=polaris -l walltime=30:00 -- a.out`
-	* run a.out on 4 chunks on polaris with a walltime of 30 minutes; charge my_allocation;
+* `qsub -A my_allocation -l select=4:system=polaris -l walltime=30:00 -q debug-scaling -- a.out`
+	* run a.out on 4 chunks on polaris with a walltime of 30 minutes in debug-scaling queue; charge my_allocation;
 	* Since we allocate full nodes on Polaris, 4 chunks will be 4 nodes.  If we shared nodes, that would be 4 cores.
 	* use the -- (dash dash) syntax when directly running an executable.
 * `qsub -A my_allocation -l place=scatter -l select=32:ncpus=32 -q prod -l walltime=30:00 mpi_mm_64.sh`
@@ -340,6 +340,8 @@ A sample submission script with directives is below for a 4-node job with 32 MPI
 #PBS -N AFFINITY
 #PBS -l select=4:ncpus=256
 #PBS -l walltime=0:10:00
+#PBS -q debug-scaling
+#PBS -A Catalyst
 
 NNODES=`wc -l < $PBS_NODEFILE`
 NRANKS=32 # Number of MPI ranks to spawn per node


### PR DESCRIPTION
I think all the examples now specify queue and project info.