### PR TITLE
`conda/2022-07-19` --> `conda` in `{deepspeed.md,python.md}`

### DIFF
--- a/docs/polaris/data-science-workflows/deepspeed.md
+++ b/docs/polaris/data-science-workflows/deepspeed.md
@@ -28,7 +28,7 @@ We focus on the `cifar` example provided in the [DeepSpeedExamples](https://gith
 
 2. Load `conda` module and activate base environment:
     ```shell
-    $ module load conda/2022-07-19
+    $ module load conda
     $ conda activate base
     $ which python3
     /soft/datascience/conda/2022-07-19/mconda3/bin/python3

--- a/docs/polaris/data-science-workflows/python.md
+++ b/docs/polaris/data-science-workflows/python.md
@@ -8,7 +8,7 @@ Users can activate this environment by first loading the `conda` module, and the
 Explicitly (either from an interactive job, or inside a job script):
 
 ```bash
-$ module load conda/2022-07-19
+$ module load conda
 $ conda activate base
 (base) $ which python3
 /soft/datascience/conda/2022-07-19/mconda3/bin/python3
@@ -21,7 +21,7 @@ To extend this environment (e.g. install additional packages), users can create 
 This can be done by:
 
 ```bash
-$ module load conda/2022-07-19
+$ module load conda
 $ conda activate base
 (base) $ conda create --clone base --prefix /path/to/envs/base-clone
 (base) $ conda activate /path/to/envs/base-clone


### PR DESCRIPTION
Removes hardcoded dates from `module load conda` instructions