### PR TITLE
Add documentation on the Deep Learning Frameworks.

### DIFF
--- a/docs/polaris/data-science-workflows/frameworks/jax.md
+++ b/docs/polaris/data-science-workflows/frameworks/jax.md
@@ -1,0 +1,91 @@
+# JAX
+
+JAX is another popular python package for accelerated computing.  JAX is built on XLA (the same XLA TensorFlow uses) as well as AutoGrad, and additionally has acceleration tools that operate on functions such as `vmap`, `jit`, etc.  JAX is not as widespread in machine learning as TensorFlow and PyTorch for traditional models (Computer Vision, Language Models) though it is quickly gaining promienence.  JAX is very powerful when a program needs non-traditional autodifferentiation or vectorizatoin, such as: forward-mode AD, higher order derivatives, Jacobians, Hessians, or any combination of the above.  Users of JAX on Polaris are encouraged to read the [user documentation](https://jax.readthedocs.io/en/latest/) in detail, particularly the details about pure-functional programming, no in-place operations, and the common mistakes in writing functions for the `@jit` decorator.
+
+## JAX on Polaris
+
+JAX is installed on Polaris via the `conda` module, available with:
+```bash
+module load conda
+conda activate
+```
+
+Then, you can load JAX in `python` as usual (below showing results from the `conda/2022-07-19` module):
+
+```python
+>>> import torch
+>>> torch.__version__
+'0.3.15'
+>>>
+```
+
+## Notes on JAX 0.3.15
+
+On Polaris, due to a bug, an environment variable must be set to use JAX on GPUs.  The following code will crash:
+```python
+import jax.numpy as numpy
+a = numpy.zeros(1000)
+```
+outputting an error that looks like:
+```python
+jaxlib.xla_extension.XlaRuntimeError: UNKNOWN: no kernel image is available for execution on the device
+```
+
+You can fix this by setting an environment variable:
+```bash
+export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1"
+```
+
+## Scaling JAX to multiple GPUs and multiple Nodes
+
+Jax has intrinsic scaling tools to use multiple GPUs on a single node, via the `pmap` function.  If this is sufficient for your needs, excellent.  If not, another alternative is to use the newer package [mpi4jax](https://github.com/mpi4jax/mpi4jax).
+
+MPI4JAX is still new and requires setting some environment variables for good performance and usability:
+- Set `MPI4JAX_USE_CUDA_MPI=1` to use CUDA-Aware MPI, supported in the `conda` module, to do operations directly from the GPU.
+- Set `CUDA_ROOT=$CUDA_HOMEMPICH_GPU_SUPPORT_ENABLED=1`
+
+The following code, based off of a test script from the mpi4jax repository, can help you verify you are using mpi4jax properly:
+
+```python
+import os
+from mpi4py import MPI
+import jax
+import jax.numpy as jnp
+import mpi4jax
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+local_rank = int(os.environ["PMI_LOCAL_RANK"])
+
+available_devices = jax.devices("gpu")
+if len(available_devices) <= local_rank:
+    raise Exception("Could not find enough GPUs")
+
+target_device = available_devices[local_rank]
+
+
+@jax.jit
+def foo(arr):
+   arr = arr + rank
+   arr_sum, _ = mpi4jax.allreduce(arr, op=MPI.SUM, comm=comm)
+   return arr_sum
+
+with jax.default_device(target_device):
+    a = jnp.zeros((3, 3))
+    print(f"Rank {rank}, local rank {local_rank}, a.device is {a.device()}")
+    result = foo(a)
+    print(f"Rank {rank}, local rank {local_rank}, result.device is {result.device()}")
+
+    import time
+    print("Sleeping for 5 seconds if you want to look at nvidia-smi ... ")
+    import time
+    time.sleep(5)
+    print("Done sleeping")
+
+if rank == 0:
+   print(result)
+
+```
+
+
+JAX and MPI4JAX are both still somewhat early in their software lifecycles.  Updates are frequent, and if you require assistance please contact support@alcf.anl.gov

--- a/docs/polaris/data-science-workflows/frameworks/pytorch.md
+++ b/docs/polaris/data-science-workflows/frameworks/pytorch.md
@@ -1,0 +1,61 @@
+# Pytorch on Polaris
+
+Pytorch is a popular, open source deep learning framework developed and released by Facebook.  The [Pytorch home page](https://pytorch.org/) has more information about Pytorch, which you can refer to.  For trouble shooting on Polaris, please contact support@alcf.anl.gov.
+
+## Installation on Polaris
+
+Pytorch is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
+
+```bash
+module load conda
+conda activate
+```
+
+Then, you can load Pytorch in `python` as usual (below showing results from the `conda/2022-07-19` module):
+
+```python
+>>> import torch
+>>> torch.__version__
+'1.12.0a0+git67ece03'
+>>>
+```
+
+This installation of Pytorch was built from source and the cuda libraries it uses are found via the `CUDA_HOME` environment variable (below showing results from the `conda/2022-07-19` module):
+
+```bash
+$ echo $CUDA_HOME
+/soft/datascience/cuda/cuda_11.5.2_495.29.05_linux
+```
+
+If you need to build applications that use this version of Pytorch and CUDA, we recommend using these cuda libraries to ensure compatibility.  We periodically update the Pytorch release, though updates will come in the form of new versions of the `conda` module.
+
+Pytorch is also available through nvidia containers that have been translated to Singularity containers.  For more information about containers, please see the [containers](../containers/containers.md) documentation page.
+
+## Pytorch Best Practices on Polaris
+
+### Single Node Performance
+
+When running Pytorch applications, we have found the following practices to be generally, if not universally, useful and encourage you to try some of these techniques to boost performance of your own applications.
+
+1. Use Reduced Precision. Reduced Precision is available on A100 via tensorcores and is supported with Pytorch operations.  In general, the way to do this is via the Pytorch Automatic Mixed Precision package (AMP), as descibed in the [mixed precision documentation](https://pytorch.org/docs/stable/amp.html).  In Pytorch, users generally need to manage casting and loss scaling manually,  though context managers and function decorators can provide easy tools to do this.
+
+2. Pytorch has a `JIT` module as well as backends to support op fusion, similar to Tensorflow's `tf.function` tools.  However, pytorch JIT capabilities are newer and may not yield performance improvements.  Please see [TorchScript](https://pytorch.org/docs/stable/jit.html) for more information.
+
+
+## Multi-GPU / Multi-Node Scale up
+
+Pytorch is compatible with scaling up to multiple GPUs per node, and across multiple nodes.  Good scaling performance has been seen up to the entire Polaris system, > 2048 GPUs.  Good performance with Pytorch has been seen with both DDP and horovod.  For details, please see the [horovod documentation](https://horovod.readthedocs.io/en/stable/Pytorch.html) or the [Distributed Data Parallel documentation](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).  Some polaris specific details that may be helpful to you:
+
+1. CPU affinity and NCCL settings can improve scaling performance, particularly at the largest scales.  In particular, we encourage users to try their scaling measurements with the following settings:
+ - Set the environment variable `NCCL_COLLNET_ENABLE=1`
+ - Set the environment varialbe `NCCL_NET_GDR_LEVEL=PHB`
+ - Manually set the CPU affinity via mpiexec, such as with `--cpu-bind verbose,list:0,8,16,24
+`
+
+2. Horovod and DDP work best when you limit the visible devices to only one GPU.  Note that if you import `mpi4py` or `horovod`, and then do something like `os.environ["CUDA_VISIBLE_DEVICES"] = hvd.local_rank()`, it may not actually work!  You must set the `CUDA_VISIBLE_DEVICES` environment variable prior to doing `MPI.COMM_WORLD.init()`, which is done in `horovod.init()` as well as implicitly in `from mpi4py import MPI`.   On Polaris specifically, you can use the environment variable `PMI_LOCAL_RANK` (as well as `PMI_LOCAL_SIZE`) to learn information about the node-local MPI ranks.  
+
+## Pytorch Dataloaders
+
+## TODO
+
+

--- a/docs/polaris/data-science-workflows/frameworks/pytorch.md
+++ b/docs/polaris/data-science-workflows/frameworks/pytorch.md
@@ -1,17 +1,17 @@
-# Pytorch on Polaris
+# PyTorch on Polaris
 
-Pytorch is a popular, open source deep learning framework developed and released by Facebook.  The [Pytorch home page](https://pytorch.org/) has more information about Pytorch, which you can refer to.  For trouble shooting on Polaris, please contact support@alcf.anl.gov.
+PyTorch is a popular, open source deep learning framework developed and released by Facebook.  The [PyTorch home page](https://pytorch.org/) has more information about Pytorch, which you can refer to.  For trouble shooting on Polaris, please contact support@alcf.anl.gov.
 
 ## Installation on Polaris
 
-Pytorch is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
+PyTorch is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
 
 ```bash
 module load conda
 conda activate
 ```
 
-Then, you can load Pytorch in `python` as usual (below showing results from the `conda/2022-07-19` module):
+Then, you can load PyTorch in `python` as usual (below showing results from the `conda/2022-07-19` module):
 
 ```python
 >>> import torch
@@ -20,31 +20,31 @@ Then, you can load Pytorch in `python` as usual (below showing results from the 
 >>>
 ```
 
-This installation of Pytorch was built from source and the cuda libraries it uses are found via the `CUDA_HOME` environment variable (below showing results from the `conda/2022-07-19` module):
+This installation of PyTorch was built from source and the cuda libraries it uses are found via the `CUDA_HOME` environment variable (below showing results from the `conda/2022-07-19` module):
 
 ```bash
 $ echo $CUDA_HOME
 /soft/datascience/cuda/cuda_11.5.2_495.29.05_linux
 ```
 
-If you need to build applications that use this version of Pytorch and CUDA, we recommend using these cuda libraries to ensure compatibility.  We periodically update the Pytorch release, though updates will come in the form of new versions of the `conda` module.
+If you need to build applications that use this version of PyTorch and CUDA, we recommend using these cuda libraries to ensure compatibility.  We periodically update the PyTorch release, though updates will come in the form of new versions of the `conda` module.
 
-Pytorch is also available through nvidia containers that have been translated to Singularity containers.  For more information about containers, please see the [containers](../containers/containers.md) documentation page.
+PyTorch is also available through nvidia containers that have been translated to Singularity containers.  For more information about containers, please see the [containers](../containers/containers.md) documentation page.
 
-## Pytorch Best Practices on Polaris
+## PyTorch Best Practices on Polaris
 
 ### Single Node Performance
 
-When running Pytorch applications, we have found the following practices to be generally, if not universally, useful and encourage you to try some of these techniques to boost performance of your own applications.
+When running PyTorch applications, we have found the following practices to be generally, if not universally, useful and encourage you to try some of these techniques to boost performance of your own applications.
 
-1. Use Reduced Precision. Reduced Precision is available on A100 via tensorcores and is supported with Pytorch operations.  In general, the way to do this is via the Pytorch Automatic Mixed Precision package (AMP), as descibed in the [mixed precision documentation](https://pytorch.org/docs/stable/amp.html).  In Pytorch, users generally need to manage casting and loss scaling manually,  though context managers and function decorators can provide easy tools to do this.
+1. Use Reduced Precision. Reduced Precision is available on A100 via tensorcores and is supported with PyTorch operations.  In general, the way to do this is via the PyTorch Automatic Mixed Precision package (AMP), as descibed in the [mixed precision documentation](https://pytorch.org/docs/stable/amp.html).  In Pytorch, users generally need to manage casting and loss scaling manually,  though context managers and function decorators can provide easy tools to do this.
 
-2. Pytorch has a `JIT` module as well as backends to support op fusion, similar to Tensorflow's `tf.function` tools.  However, pytorch JIT capabilities are newer and may not yield performance improvements.  Please see [TorchScript](https://pytorch.org/docs/stable/jit.html) for more information.
+2. PyTorch has a `JIT` module as well as backends to support op fusion, similar to Tensorflow's `tf.function` tools.  However, PyTorch JIT capabilities are newer and may not yield performance improvements.  Please see [TorchScript](https://pytorch.org/docs/stable/jit.html) for more information.
 
 
 ## Multi-GPU / Multi-Node Scale up
 
-Pytorch is compatible with scaling up to multiple GPUs per node, and across multiple nodes.  Good scaling performance has been seen up to the entire Polaris system, > 2048 GPUs.  Good performance with Pytorch has been seen with both DDP and horovod.  For details, please see the [horovod documentation](https://horovod.readthedocs.io/en/stable/Pytorch.html) or the [Distributed Data Parallel documentation](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).  Some polaris specific details that may be helpful to you:
+PyTorch is compatible with scaling up to multiple GPUs per node, and across multiple nodes.  Good scaling performance has been seen up to the entire Polaris system, > 2048 GPUs.  Good performance with PyTorch has been seen with both DDP and horovod.  For details, please see the [horovod documentation](https://horovod.readthedocs.io/en/stable/Pytorch.html) or the [Distributed Data Parallel documentation](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).  Some polaris specific details that may be helpful to you:
 
 1. CPU affinity and NCCL settings can improve scaling performance, particularly at the largest scales.  In particular, we encourage users to try their scaling measurements with the following settings:
  - Set the environment variable `NCCL_COLLNET_ENABLE=1`
@@ -54,7 +54,7 @@ Pytorch is compatible with scaling up to multiple GPUs per node, and across mult
 
 2. Horovod and DDP work best when you limit the visible devices to only one GPU.  Note that if you import `mpi4py` or `horovod`, and then do something like `os.environ["CUDA_VISIBLE_DEVICES"] = hvd.local_rank()`, it may not actually work!  You must set the `CUDA_VISIBLE_DEVICES` environment variable prior to doing `MPI.COMM_WORLD.init()`, which is done in `horovod.init()` as well as implicitly in `from mpi4py import MPI`.   On Polaris specifically, you can use the environment variable `PMI_LOCAL_RANK` (as well as `PMI_LOCAL_SIZE`) to learn information about the node-local MPI ranks.  
 
-## Pytorch Dataloaders
+## PyTorch Dataloaders
 
 ## TODO
 

--- a/docs/polaris/data-science-workflows/frameworks/pytorch.md
+++ b/docs/polaris/data-science-workflows/frameworks/pytorch.md
@@ -54,8 +54,13 @@ PyTorch is compatible with scaling up to multiple GPUs per node, and across mult
 
 2. Horovod and DDP work best when you limit the visible devices to only one GPU.  Note that if you import `mpi4py` or `horovod`, and then do something like `os.environ["CUDA_VISIBLE_DEVICES"] = hvd.local_rank()`, it may not actually work!  You must set the `CUDA_VISIBLE_DEVICES` environment variable prior to doing `MPI.COMM_WORLD.init()`, which is done in `horovod.init()` as well as implicitly in `from mpi4py import MPI`.   On Polaris specifically, you can use the environment variable `PMI_LOCAL_RANK` (as well as `PMI_LOCAL_SIZE`) to learn information about the node-local MPI ranks.  
 
+### DeepSpeed
+
+DeepSpeed is also available and usable on Polaris.  For more information, please see the [DeepSpeed](../deepspeed.md) documentation directly.
+
 ## PyTorch Dataloaders
 
 ## TODO
 
+More information about PyTorch Dataloaders is coming soon.  Meanwhile, please note there is a bug that causes a hang when using pytorch data loaders + distributed training (horovod, DDP, etc).  To workaround this, Nvidia recommends setting `num_workers=0` in the dataloader configuration.
 

--- a/docs/polaris/data-science-workflows/frameworks/tensorflow.md
+++ b/docs/polaris/data-science-workflows/frameworks/tensorflow.md
@@ -7,11 +7,11 @@ Tensorflow is a popular, open source deep learning framework developed and relea
 Tensorflow is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
 
 ```bash
-module load conda/2022-07-19
+module load conda
 conda activate
 ```
 
-Then, you can load tensorflow in `python` as usual:
+Then, you can load tensorflow in `python` as usual (below showing results from the `conda/2022-07-19` module):
 
 ```python
 >>> import tensorflow as tf
@@ -20,7 +20,7 @@ Then, you can load tensorflow in `python` as usual:
 >>>
 ```
 
-This installation of tensorflow was built from source and the cuda libraries it uses (11.5) are found via the `CUDA_HOME` environment variable:
+This installation of tensorflow was built from source and the cuda libraries it uses are found via the `CUDA_HOME` environment variable (below showing results from the `conda/2022-07-19` module):
 
 ```bash
 $ echo $CUDA_HOME

--- a/docs/polaris/data-science-workflows/frameworks/tensorflow.md
+++ b/docs/polaris/data-science-workflows/frameworks/tensorflow.md
@@ -1,17 +1,17 @@
-# Tensorflow on Polaris
+# TensorFlow on Polaris
 
-Tensorflow is a popular, open source deep learning framework developed and released by Google.  The [Tensorflow home page](https://www.tensorflow.org/) has more information about Tensorflow, which you can refer to.  For trouble shooting on Polaris, please contact support@alcf.anl.gov.
+TensorFlow is a popular, open source deep learning framework developed and released by Google.  The [TensorFlow home page](https://www.tensorflow.org/) has more information about TensorFlow, which you can refer to.  For trouble shooting on Polaris, please contact support@alcf.anl.gov.
 
 ## Installation on Polaris
 
-Tensorflow is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
+TensorFlow is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
 
 ```bash
 module load conda
 conda activate
 ```
 
-Then, you can load tensorflow in `python` as usual (below showing results from the `conda/2022-07-19` module):
+Then, you can load TensorFlow in `python` as usual (below showing results from the `conda/2022-07-19` module):
 
 ```python
 >>> import tensorflow as tf
@@ -20,32 +20,32 @@ Then, you can load tensorflow in `python` as usual (below showing results from t
 >>>
 ```
 
-This installation of tensorflow was built from source and the cuda libraries it uses are found via the `CUDA_HOME` environment variable (below showing results from the `conda/2022-07-19` module):
+This installation of TensorFlow was built from source and the cuda libraries it uses are found via the `CUDA_HOME` environment variable (below showing results from the `conda/2022-07-19` module):
 
 ```bash
 $ echo $CUDA_HOME
 /soft/datascience/cuda/cuda_11.5.2_495.29.05_linux
 ```
 
-If you need to build applications that use this version of tensorflow and CUDA, we recommend using these cuda libraries to ensure compatibility.  We periodically update the tensorflow release, though updates will come in the form of new versions of the `conda` module.
+If you need to build applications that use this version of TensorFlow and CUDA, we recommend using these cuda libraries to ensure compatibility.  We periodically update the TensorFlow release, though updates will come in the form of new versions of the `conda` module.
 
-Tensorflow is also available through nvidia containers that have been translated to Singularity containers.  For more information about containers, please see the containers documentation page.
+TensorFlow is also available through nvidia containers that have been translated to Singularity containers.  For more information about containers, please see the [containers](../containers/containers.md) documentation page.
 
-## Tensorflow Best Practices on Polaris
+## TensorFlow Best Practices on Polaris
 
 ### Single Node Performance
 
-When running tensorflow applications, we have found the following practices to be generally, if not universally, useful and encourage you to try some of these techniques to boost performance of your own applications.
+When running TensorFlow applications, we have found the following practices to be generally, if not universally, useful and encourage you to try some of these techniques to boost performance of your own applications.
 
-1. Use Reduced Precision. Reduced Precision is available on A100 via tensorcores and is supported with tensorflow operations.  In general, the way to do this is via the `tf.keras.mixed_precision` Policy, as descibed in the [mixed precision documentation](https://www.tensorflow.org/guide/mixed_precision).  If you use a custom training loop (and not `keras.Model.fit`), you will also need to apply [loss scaling](https://www.tensorflow.org/guide/mixed_precision#training_the_model_with_a_custom_training_loop).
+1. Use Reduced Precision. Reduced Precision is available on A100 via tensorcores and is supported with TensorFlow operations.  In general, the way to do this is via the `tf.keras.mixed_precision` Policy, as descibed in the [mixed precision documentation](https://www.tensorflow.org/guide/mixed_precision).  If you use a custom training loop (and not `keras.Model.fit`), you will also need to apply [loss scaling](https://www.tensorflow.org/guide/mixed_precision#training_the_model_with_a_custom_training_loop).
 
-2. Use tensorflow's graph API to improve efficiency of operations.  Tensorflow is, in general, an imperative language but with function decorators like `@tf.function` you can trace functions in your code.  Tracing replaces your python function with a lower-level, semi-compiled tensorflow Graph. More information about the `tf.function` interface is available [here](https://www.tensorflow.org/api_docs/python/tf/function).  When possible, use jit_compile, but be aware of sharp bits when using `tf.function`: python expressions that aren't tensors are often replaced as constants in the graph, which may or may not be your intention.
+2. Use TensorFlow's graph API to improve efficiency of operations.  TensorFlow is, in general, an imperative language but with function decorators like `@tf.function` you can trace functions in your code.  Tracing replaces your python function with a lower-level, semi-compiled TensorFlow Graph. More information about the `tf.function` interface is available [here](https://www.tensorflow.org/api_docs/python/tf/function).  When possible, use jit_compile, but be aware of sharp bits when using `tf.function`: python expressions that aren't tensors are often replaced as constants in the graph, which may or may not be your intention.
 
-3. Use [XLA compilation](https://www.tensorflow.org/xla) on your code.  XLA is the Accelerated Linear Algebra library that is available in tensorflow and critical in software like JAX.  XLA will compile a `tf.Graph` object, generated with `tf.function` or similar, and perform optimizations like operation-fusion.  XLA can give impressive performance boosts with almost no user changes except to set an environment variable `TF_XLA_FLAGS=--tf_xla_auto_jit=2`.  If your code is complex, or has dynamically sized tensors (tensors where the shape changes every iteration), XLA can be detrimental: the overhead for compiling functions can be large enough to mitigate performance improvements.  XLA is particularly powerful when combined with reduced precision, yielding speedups > 100% in some models.
+3. Use [XLA compilation](https://www.tensorflow.org/xla) on your code.  XLA is the Accelerated Linear Algebra library that is available in tensorFlow and critical in software like JAX.  XLA will compile a `tf.Graph` object, generated with `tf.function` or similar, and perform optimizations like operation-fusion.  XLA can give impressive performance boosts with almost no user changes except to set an environment variable `TF_XLA_FLAGS=--tf_xla_auto_jit=2`.  If your code is complex, or has dynamically sized tensors (tensors where the shape changes every iteration), XLA can be detrimental: the overhead for compiling functions can be large enough to mitigate performance improvements.  XLA is particularly powerful when combined with reduced precision, yielding speedups > 100% in some models.
 
 ## Multi-GPU / Multi-Node Scale up
 
-Tensorflow is compatible with scaling up to multiple GPUs per node, and across multiple nodes.  Good scaling performance has been seen up to the entire Polaris system, > 2048 GPUs.  Good performance with tensorflow has been seen with horovod in particular.  For details, please see the [horovod documentation](https://horovod.readthedocs.io/en/stable/tensorflow.html).  Some polaris specific details that may be helpful to you:
+TensorFlow is compatible with scaling up to multiple GPUs per node, and across multiple nodes.  Good scaling performance has been seen up to the entire Polaris system, > 2048 GPUs.  Good performance with tensorFlow has been seen with horovod in particular.  For details, please see the [horovod documentation](https://horovod.readthedocs.io/en/stable/tensorflow.html).  Some polaris specific details that may be helpful to you:
 
 1. CPU affinity and NCCL settings can improve scaling performance, particularly at the largest scales.  In particular, we encourage users to try their scaling measurements with the following settings:
  - Set the environment variable `NCCL_COLLNET_ENABLE=1`
@@ -54,4 +54,8 @@ Tensorflow is compatible with scaling up to multiple GPUs per node, and across m
 `
 
 2. Horovod works best when you limit the visible devices to only one GPU.  Note that if you import `mpi4py` or `horovod`, and then do something like `os.environ["CUDA_VISIBLE_DEVICES"] = hvd.local_rank()`, it may not actually work!  You must set the `CUDA_VISIBLE_DEVICES` environment variable prior to doing `MPI.COMM_WORLD.init()`, which is done in `horovod.init()` as well as implicitly in `from mpi4py import MPI`.   On Polaris specifically, you can use the environment variable `PMI_LOCAL_RANK` (as well as `PMI_LOCAL_SIZE`) to learn information about the node-local MPI ranks.  
+
+# TensorFlow Dataloaders
+
+## TODO
 

--- a/docs/polaris/data-science-workflows/frameworks/tensorflow.md
+++ b/docs/polaris/data-science-workflows/frameworks/tensorflow.md
@@ -1,0 +1,57 @@
+# Tensorflow on Polaris
+
+Tensorflow is a popular, open source deep learning framework developed and released by Google.  The [Tensorflow home page](https://www.tensorflow.org/) has more information about Tensorflow, which you can refer to.  For trouble shooting on Polaris, please contact support@alcf.anl.gov.
+
+## Installation on Polaris
+
+Tensorflow is installed on Polaris already, available in the `conda` module.  To use it from a compute node, please do:
+
+```bash
+module load conda/2022-07-19
+conda activate
+```
+
+Then, you can load tensorflow in `python` as usual:
+
+```python
+>>> import tensorflow as tf
+>>> tf.__version__
+'2.9.1'
+>>>
+```
+
+This installation of tensorflow was built from source and the cuda libraries it uses (11.5) are found via the `CUDA_HOME` environment variable:
+
+```bash
+$ echo $CUDA_HOME
+/soft/datascience/cuda/cuda_11.5.2_495.29.05_linux
+```
+
+If you need to build applications that use this version of tensorflow and CUDA, we recommend using these cuda libraries to ensure compatibility.  We periodically update the tensorflow release, though updates will come in the form of new versions of the `conda` module.
+
+Tensorflow is also available through nvidia containers that have been translated to Singularity containers.  For more information about containers, please see the containers documentation page.
+
+## Tensorflow Best Practices on Polaris
+
+### Single Node Performance
+
+When running tensorflow applications, we have found the following practices to be generally, if not universally, useful and encourage you to try some of these techniques to boost performance of your own applications.
+
+1. Use Reduced Precision. Reduced Precision is available on A100 via tensorcores and is supported with tensorflow operations.  In general, the way to do this is via the `tf.keras.mixed_precision` Policy, as descibed in the [mixed precision documentation](https://www.tensorflow.org/guide/mixed_precision).  If you use a custom training loop (and not `keras.Model.fit`), you will also need to apply [loss scaling](https://www.tensorflow.org/guide/mixed_precision#training_the_model_with_a_custom_training_loop).
+
+2. Use tensorflow's graph API to improve efficiency of operations.  Tensorflow is, in general, an imperative language but with function decorators like `@tf.function` you can trace functions in your code.  Tracing replaces your python function with a lower-level, semi-compiled tensorflow Graph. More information about the `tf.function` interface is available [here](https://www.tensorflow.org/api_docs/python/tf/function).  When possible, use jit_compile, but be aware of sharp bits when using `tf.function`: python expressions that aren't tensors are often replaced as constants in the graph, which may or may not be your intention.
+
+3. Use [XLA compilation](https://www.tensorflow.org/xla) on your code.  XLA is the Accelerated Linear Algebra library that is available in tensorflow and critical in software like JAX.  XLA will compile a `tf.Graph` object, generated with `tf.function` or similar, and perform optimizations like operation-fusion.  XLA can give impressive performance boosts with almost no user changes except to set an environment variable `TF_XLA_FLAGS=--tf_xla_auto_jit=2`.  If your code is complex, or has dynamically sized tensors (tensors where the shape changes every iteration), XLA can be detrimental: the overhead for compiling functions can be large enough to mitigate performance improvements.  XLA is particularly powerful when combined with reduced precision, yielding speedups > 100% in some models.
+
+## Multi-GPU / Multi-Node Scale up
+
+Tensorflow is compatible with scaling up to multiple GPUs per node, and across multiple nodes.  Good scaling performance has been seen up to the entire Polaris system, > 2048 GPUs.  Good performance with tensorflow has been seen with horovod in particular.  For details, please see the [horovod documentation](https://horovod.readthedocs.io/en/stable/tensorflow.html).  Some polaris specific details that may be helpful to you:
+
+1. CPU affinity and NCCL settings can improve scaling performance, particularly at the largest scales.  In particular, we encourage users to try their scaling measurements with the following settings:
+ - Set the environment variable `NCCL_COLLNET_ENABLE=1`
+ - Set the environment varialbe `NCCL_NET_GDR_LEVEL=PHB`
+ - Manually set the CPU affinity via mpiexec, such as with `--cpu-bind verbose,list:0,8,16,24
+`
+
+2. Horovod works best when you limit the visible devices to only one GPU.  Note that if you import `mpi4py` or `horovod`, and then do something like `os.environ["CUDA_VISIBLE_DEVICES"] = hvd.local_rank()`, it may not actually work!  You must set the `CUDA_VISIBLE_DEVICES` environment variable prior to doing `MPI.COMM_WORLD.init()`, which is done in `horovod.init()` as well as implicitly in `from mpi4py import MPI`.   On Polaris specifically, you can use the environment variable `PMI_LOCAL_RANK` (as well as `PMI_LOCAL_SIZE`) to learn information about the node-local MPI ranks.  
+


### PR DESCRIPTION
This PR adds 3 pages: tensorflow, pytorch, and JAX.  Reviews, if needed, could come from the datascience team.  I've tagged a couple possible reviewers already.