### PR TITLE
Fix repo URLs in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # ALCF User Guide
 
-## Contributing to Documentation
+## Contributing to documentation
 
 ### Python environment
 
@@ -21,19 +21,19 @@ $ source env/bin/activate
 
 Using Git ssh. Make sure you add ssh public key to your profile (https cloning to be deprecated soon)
 ```
-$ git clone git@github.com:argonne-lcf/alcf-userguide.git
+$ git clone git@github.com:argonne-lcf/user-guides.git
 ```
 
-### Installing Mkdocs
+### Installing MkDocs
 
 To install `mkdocs` in the current environment: 
 
 ```
-$ cd alcf-userguide
+$ cd user-guides
 $ make install-dev
 ```
 
-### Preview the Docs Locally
+### Preview the docs locally
 
 Run `mkdocs serve` or `make serve` to auto-build and serve the docs for preview in your web browser.
 ```
@@ -42,10 +42,10 @@ $ make serve
 
 ### Working on documentation
 
-* All commits must have the commit comment
-* Create your own branch from the main branch.  For this writing we are using YOURBRANCH as an example.
+* All commits must have a commit message
+* Create your own branch from the `main` branch.  For this writing we are using `YOURBRANCH` as an example.
 ```
-$ cd alcf-userguide
+$ cd user-guides
 $ git fetch --all
 $ git checkout main
 $ git pull origin main
@@ -54,7 +54,7 @@ $ git push -u origin YOURBRANCH
 ```
 * Commit your changes to the remote repo
 ```
-$ cd alcf-userguide
+$ cd user-guides
 $ git status                         # check the status of the files you have editted
 $ git commit -a -m "Updated docs"    # preferably one issue per commit
 $ git status                         # should say working tree clean
@@ -66,5 +66,5 @@ $ git merge main                     # merge the local develop into **YOURBRANCH
                                      # make sure NO merge conflicts exist
 $ git push origin YOURBRANCH         # push the changes from local branch up to your remote branch
 ```
-* Create merge request from https://github.com/argonne-lcf/alcf-userguide from YOURBRANCH to main branch.
+* Create merge request from https://github.com/argonne-lcf/user-guides from `YOURBRANCH` to `main` branch.
 


### PR DESCRIPTION
Looks like this repository was renamed at some point from `alcf-userguide` to `user-guides`. Updated the `README.md` to reflect this change. 