### PR TITLE
forgot to update mkdocs to remove pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,6 @@ nav:
     - Known Issues: polaris/known-issues.md
     - Hardware Overview:
       - Polaris Machine Overview: polaris/hardware-overview/machine-overview.md
-#      - Slingshot Network: polaris/hardware-overview/slingshot-network.md
     - Compiling and Linking:
       - Compiling and Linking Overview: polaris/compiling-and-linking/compiling-and-linking-overview.md
       - Programming Models: polaris/compiling-and-linking/polaris-programming-models.md
@@ -61,7 +60,6 @@ nav:
             - Jax: polaris/data-science-workflows/frameworks/jax.md
             - DeepSpeed: polaris/data-science-workflows/frameworks/deepspeed.md
         - Applications:
-#            - Balsam: polaris/data-science-workflows/applications/balsam.md
             - gpt-neox: polaris/data-science-workflows/applications/gpt-neox.md
     - Programming Models:
         - OpenMP: polaris/programming-models/openmp-polaris.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ nav:
     - Known Issues: polaris/known-issues.md
     - Hardware Overview:
       - Polaris Machine Overview: polaris/hardware-overview/machine-overview.md
-      - Slingshot Network: polaris/hardware-overview/slingshot-network.md
+#      - Slingshot Network: polaris/hardware-overview/slingshot-network.md
     - Compiling and Linking:
       - Compiling and Linking Overview: polaris/compiling-and-linking/compiling-and-linking-overview.md
       - Programming Models: polaris/compiling-and-linking/polaris-programming-models.md
@@ -61,7 +61,7 @@ nav:
             - Jax: polaris/data-science-workflows/frameworks/jax.md
             - DeepSpeed: polaris/data-science-workflows/frameworks/deepspeed.md
         - Applications:
-            - Balsam: polaris/data-science-workflows/applications/balsam.md
+#            - Balsam: polaris/data-science-workflows/applications/balsam.md
             - gpt-neox: polaris/data-science-workflows/applications/gpt-neox.md
     - Programming Models:
         - OpenMP: polaris/programming-models/openmp-polaris.md


### PR DESCRIPTION
The mkdocs.yaml file wasn't updated when two pages were removed in https://github.com/argonne-lcf/user-guides/pull/84.

Using '#' to comment out the pages is good and helps as reminder that we need to create the pages? Or just delete the entries (i.e. no comments in file)?

@yghadar @bethcerny 