### PR TITLE
Gpt neox

### DIFF
--- a/docs/polaris/data-science-workflows/applications/gpt-neox.md
+++ b/docs/polaris/data-science-workflows/applications/gpt-neox.md
@@ -2,6 +2,8 @@
 
 We include below a set of instructions to get [`EleutherAI/gpt-neox`](https://github.com/EleutherAI/gpt-neox) running on Polaris.
 
+A batch submission script for the following example is available [here](https://github.com/argonne-lcf/GettingStarted/blob/master/DataScience/DeepSpeed/gpt-neox/README.md).
+
 !!! note
 
     The instructions below should be **ran directly from a compute node**.


### PR DESCRIPTION
Merge pull request from Thomas Brettin (@brettin) that adds missing whitespace to `gpt-neox.md`:

add missing space between before `slots=4`:
```
sed -e 's/$/ slots=4/' -i hostfile
```

https://github.com/saforem2/user-guides/pull/1/commits