### PR TITLE
Updated jupyter hub docs

### DIFF
--- a/docs/services/jupyter-hub.md
+++ b/docs/services/jupyter-hub.md
@@ -1,7 +1,7 @@
 # Jupyter Hub
 ## Using Jupyter Hub
 
-JupyterHub is an open-source application to allow multiple users to launch Jupyter Notebooks from a central location. At ALCF users can use the JupyterHub instances at https://jupyter.alcf.anl.gov to run notebooks on servers connect to the compute resource or on the compute resource itself.
+JupyterHub is an open-source application to allow multiple users to launch Jupyter Notebooks from a central location. At ALCF users can use the JupyterHub instances at [https://jupyter.alcf.anl.gov](https://jupyter.alcf.anl.gov) to run notebooks on servers connect to the compute resource or on the compute resource itself.
 
 The JupyterHub instance assigned to Cooley start notebooks on a login node.  The JupyterHub instance assigned to theta run notebooks a server external to Theta.  This instance does not have access to HPE/Cray programing environment and tools located in ``/opt/cray, opt/intel, etc.``.  These instances provide users access to their home (/home/$USER) and project folders on theta-lustre, grand and eagle file systems (/home/$USER, /project, /grand, /eagle) using symbolic links in the home directory.
 
@@ -16,8 +16,9 @@ For more information on how to manage conda environments, refer to this [page](h
 
 From a terminal:
 ```
-# Source required conda environment variables from appropriate install
-. /soft/systems/jupyterhub/miniconda3/etc/profile.d/conda.sh
+# Load a conda module
+module load conda
+conda activate base
 
 # set shell proxy variables to access external URL
 export http_proxy=http://proxy.alcf.anl.gov:3128


### PR DESCRIPTION
This changes the instructions on how to load a conda environment to work with in order to create a custom environment for Jupyter notebooks.  Myself and some others found that the script that is sourced doesn't set environment variables that allow a user to create a local environment (it tries to write the environment to `/soft`).  I'm not sure if this is the right approach, but this worked for me.