### PR TITLE
Updating Cobalt xgitlab repo to new git.cels links

### DIFF
--- a/docs/theta-gpu/queueing-and-running-jobs/job-and-queue-scheduling.md
+++ b/docs/theta-gpu/queueing-and-running-jobs/job-and-queue-scheduling.md
@@ -159,7 +159,7 @@ mpirun -np 20 -npernode 10 ./my_app
 ```
 
 ## Job Submission on ThetaGPU
-The queuing system used on ThetaGPU is [Cobalt](https://xgitlab.cels.anl.gov/aig-public/cobalt). On ThetaGPU, Cobalt jobs may run either as script jobs or interactive mode jobs.
+The queuing system used on ThetaGPU is [Cobalt](https://git.cels.anl.gov/aig-public/cobalt). On ThetaGPU, Cobalt jobs may run either as script jobs or interactive mode jobs.
 
 ##  Script Method
 In the script method, Cobalt will execute a user-supplied script when running a user’s job. Following are the required flags to `qsub`, as well as some of the more common options. A complete list of options may be found as a part of the `qsub` manpage, available on any login node.
@@ -208,7 +208,7 @@ qsub -A YourProject -n 4 -t 30 -q full-node \
 –attrs filesystems=home,eagle \
 program.exe progarg1
 ```
-The syntax for Cobalt scripting is slightly different than that of a PBS script. For more information, see [Cobalt scripting](https://xgitlab.cels.anl.gov/aig-public/cobalt/-/wikis/cmdref/CommandReference).
+The syntax for Cobalt scripting is slightly different than that of a PBS script. For more information, see [Cobalt scripting](https://git.cels.anl.gov/aig-public/cobalt/-/wikis/cmdref/CommandReference).
 
 ## Interactive Method
 To run an “interactive mode” job on ALCF Cray resources, add the “-I” (uppercase "i", not a lowercase "L") flag or “--mode interactive” to your qsub line and omit any executable. Your qsub submission will then wait until nodes are allocated to your job and Cobalt will start a shell on a job-launch node on your behalf. You may aprun against your assigned resources and run other interactive commands from this node. It is important to note that your shell is executed from a launch node and not from your compute head-node. Once your allocation ends, all apruns will be terminated, but your shell will remain for any cleanup actions that you choose to take.

--- a/docs/theta/queueing-and-running-jobs/job-and-queue-scheduling.md
+++ b/docs/theta/queueing-and-running-jobs/job-and-queue-scheduling.md
@@ -81,7 +81,7 @@ Time spent booting or rebooting nodes to obtain requested modes will not be char
 Failure to specify a mode will result in the selection of cache-quad, the equivalent of listing `#!--attrs mcdram=cache:numa=quad` in your qsub or job script.
 
 ## Submit a Job
-The queuing system used at ALCF is [Cobalt](https://xgitlab.cels.anl.gov/aig-public/cobalt). On Theta, Cobalt jobs may run either as script jobs or interactive mode jobs.
+The queuing system used at ALCF is [Cobalt](https://git.cels.anl.gov/aig-public/cobalt). On Theta, Cobalt jobs may run either as script jobs or interactive mode jobs.
 
 ### Script Method
 In the script method, Cobalt will execute a user-supplied script when running a user’s job. All scripts on Theta must have their execute bit set, and must be able to run on a standard x86_64 architecture. Following are the required flags to qsub, as well as some of the more common options. A complete list of options may be found as a part of the qsub manpage, available on any login node.


### PR DESCRIPTION
Links to xgitlab are breaking.  Cobalt's repo has been moved to git.cels and this updates the links to them.
