### PR TITLE
fix docmentation link that was broken with cerebras release 1.8.0

### DIFF
--- a/docs/ai-testbed/cerebras/README.md
+++ b/docs/ai-testbed/cerebras/README.md
@@ -4,7 +4,7 @@
 
 [Getting Started](./getting-started.md)
 
-[Virtual Environment](./virtual-environments.md)
+[Customizing Environment](./customizing-environment.md)
 
 [Running a Model/Program](./running-a-model-or-program.md)
 

--- a/docs/ai-testbed/cerebras/README.md
+++ b/docs/ai-testbed/cerebras/README.md
@@ -1,4 +1,4 @@
-# Graphcore
+# Cerebras
 
 [System Overview](./system-overview.md)
 

--- a/docs/ai-testbed/cerebras/miscellaneous.md
+++ b/docs/ai-testbed/cerebras/miscellaneous.md
@@ -2,9 +2,8 @@
 
 ## Porting applications to the CS-2
 
-There is some documentation on the Cerebras documentation site that is helpful.<br>
-[Porting PyTorch Model to CS](https://docs.cerebras.net/en/latest/pytorch-docs/adapting-pytorch-to-cs.html)<br>
-[Port TensorFlow to Cerebras](https://docs.cerebras.net/en/latest/tensorflow-docs/porting-tf-to-cs/index.html)
+Cerebras documentation for porting code to run on a Cerebras CS-2 system:<br>
+[Ways to port your model](https://docs.cerebras.net/en/latest/wsc/port/index.html)
 
 <!---
 ## Determining the CS-2 version


### PR DESCRIPTION
Fix docmentation link that was broken with cerebras release 1.8.0
