### PR TITLE
consolidated and augmented known issues

### DIFF
--- a/docs/aurora/getting-started-on-aurora.md
+++ b/docs/aurora/getting-started-on-aurora.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-*** ACCESS IS CURRENTLY ENABLED FOR ESP and ECP TEAM ONLY ***
+*** ACCESS IS CURRENTLY ENABLED FOR ESP and ECP TEAMS ONLY ***
 
 The pre-requisites required for Sunspot are applicable to Aurora as well. See this [page](https://www.alcf.anl.gov/support-center/aurorasunspot/getting-started-sunspot#pre-req) for more information.
 
@@ -36,11 +36,9 @@ ECP and ESP users will be added to a CNDA Slack workspace, where CNDA discussion
 
 ## Known Issues
 
-A known issues [page](https://wiki.jlse.anl.gov/display/inteldga/Known+Issues) can be found in the JLSE Wiki space used for NDA content. Note that this page requires a JLSE Aurora early hw/sw resource account for access.
+See this [page](https://docs.alcf.anl.gov/aurora/known-issues/) for known issues.
 
-* Interim Filesystem: The early access filesystem is not highly performant. Intermittent hangs or pauses should be expected - waiting for IO to complete is recommended and IO completions should pass without failure. Jobs requiring significant filesystem performance must be avoided at this time.
-* Large number of Machine Check Events from the PVC, that causes nodes to panic and reboot.
-* HBM mode is not automatically validated. Jobs requiring flat memory mode should test by looking  at `numactl -H` for 4 NUMA memory nodes instead of 16 on the nodes.
+A known issues [page](https://apps.cels.anl.gov/confluence/display/inteldga/Known+Issues) can be found in the JLSE Wiki space used for NDA content. Note that this page requires a JLSE Aurora early hw/sw resource account for access. See [page](https://docs.alcf.anl.gov/aurora/known-issues/) for other known issues.
 
 ## Allocation usage
 

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -2,6 +2,7 @@
 
 This is a collection of known issues that have been encountered during Aurora's early user phase. Documentation will be updated as issues are resolved. Users are encouraged to email [support@alcf.anl.gov](mailto:support@alcf.anl.gov) to report issues.
 
+A known issues [page](https://apps.cels.anl.gov/confluence/display/inteldga/Known+Issues) can be found in the JLSE Wiki space used for NDA content. Note that this page requires a JLSE Aurora early hw/sw resource account for access.
 
 ## Running Applications
 
@@ -29,3 +30,11 @@ Jobs may fail to successfully start at times (particularly at higher node counts
 
 2. In the event of a node going down during a job, users may encounter messages such as `ping failed on x4616c0s4b0n0: Application 047a3c9f-fb41-4595-a2ad-4a4d0ec1b6c1 not found`. The node will likely have started a reboot and won't be included in jobs again until checks pass.
 
+To increase the chances that a large job does not terminate due to a node failure, you may choose to interactively route your MPI job around nodes that fail during your run. See this page on [Working Around Node Failures](https://docs.alcf.anl.gov/aurora/running-jobs-aurora/#working-around-node-failures) for more information.
+## Other issues
+
+* Interim Filesystem: The early access filesystem is not highly performant. Intermittent hangs or pauses should be expected - waiting for IO to complete is recommended and IO completions should pass without failure. Jobs requiring significant filesystem performance must be avoided at this time.
+* Large number of Machine Check Events from the PVC, that causes nodes to panic and reboot.
+* HBM mode is not automatically validated. Jobs requiring flat memory mode should test by looking  at `numactl -H` for 4 NUMA memory nodes instead of 16 on the nodes.
+* Application failures at large node-count are being tracked in the CNDA Slack workspace. See this [canvas table](https://alcf-cnda.slack.com/canvas/C05HMK7DD4J?focus_section_id=temp:C:EYXdcf8f1d1b86d44428a9abab5b) for more information and to document your case. ESP and ECP project members with access to Aurora should have access to the CNDA slack workspace. Contact support@alcf.anl.gov if you have have access to Aurora and belong to an ESP or ECP project,  but are not in the CNDA Slack workspace.
+* Application failures at single-node are tracked in the JLSE wiki/confluence [page](https://apps.cels.anl.gov/confluence/pages/viewpage.action?pageId=4784336)


### PR DESCRIPTION
- fixed a typo in getting-started-on-aurora.md
- moved content in known issues section in getting-started-on-aurora.md to known-issues.md
- added a pointer to node failures workaround section from running-jobs-on-aurora.md in known-issues.md