### PR TITLE
new-user Aurora access request instructions for ESP team members

### DIFF
--- a/docs/aurora/getting-started-on-aurora.md
+++ b/docs/aurora/getting-started-on-aurora.md
@@ -4,7 +4,32 @@
 
 *** ACCESS IS CURRENTLY ENABLED FOR ESP and ECP TEAMS ONLY ***
 
-The pre-requisites required for Sunspot are applicable to Aurora as well. See this [page](https://www.alcf.anl.gov/support-center/aurorasunspot/getting-started-sunspot#pre-req) for more information.
+
+## How to Get Access to Aurora (for New Users)
+
+### If You Already Have Access to Sunspot
+
+If you already have access to Sunspot, all you need to do to gain access to Aurora is send an email to support@alcf.anl.gov requesting access to Aurora. In your email, include
+
+* Your ALCF username
+* Your institutional email address
+* The ESP or ECP project in which you are a member
+
+### For Aurora Early Science Program (ESP) Team Members
+
+If you have never had access to Sunspot, here are the steps to gain access to Aurora:
+
+1. Verify that your institution has signed a CNDA with Intel that covers you.
+2. If you do not have an active ALCF account, request one using the [ALCF Account request webpage](https://accounts.alcf.anl.gov/#/accountRequest). When you come to the part about joining a project, request the `ProjectName_aesp_CNDA` project.
+3. Acknowledge the Intel Terms of Use agreement (TOU) for the Aurora Software Development Kit (SDK) by submitting [this form](https://events.cels.anl.gov/event/147/surveys/7).
+
+Getting a new ALCF account typically takes anywhere from a few days to a few weeks (processing new access for foreign nationals is what can take weeks). After you acknowledge the TOU, there is a manual step that typically takes a few days. You will receive an email notifying you when Aurora access is granted, including some getting started instructions.
+
+### For Aurora Exascale Computing Project (ECP) Team Members
+
+See this [page](https://www.alcf.anl.gov/support-center/aurorasunspot/getting-started-sunspot#pre-req) for instructions.
+
+## Caveats About Using Aurora and Reporting Findings
 
 NOTE: Sharing of any results from Aurora publicly no longer requires a review or approval from Intel. However, anyone publishing these results should include the following in their materials: 
 


### PR DESCRIPTION
Instructions for new Aurora users on ESP teams to request Aurora access (if they didn't already have Sunspot access).
