### PR TITLE
update ssh+git on getting started page

### DIFF
--- a/docs/aurora/getting-started-on-aurora.md
+++ b/docs/aurora/getting-started-on-aurora.md
@@ -151,13 +151,13 @@ Host github.com gitlab.com bitbucket.org
 	ProxyCommand /usr/bin/socat - PROXY:proxy.alcf.anl.gov:%h:%p,proxyport=3128
 ```
 
-If you need to use soemthing besides your default SSH key on Aurora for authentication to GitHub in conjunction with the above SSH workaround, you may set
+If you need to use something besides your default SSH key on Aurora for authentication to GitHub in conjunction with the above SSH workaround, you may set
 
 ```
-export GIT_SSH_COMMAND="ssh -i ~/.ssh/specialGitKey -F /dev/null"
+export GIT_SSH_COMMAND="ssh -i ~/.ssh/specialGitKey"
 ```
 
-where specialGitKey is the name of the private key in your `.ssh` directory, for which you have uploaded the public key to GitHub.
+where specialGitKey is the name of the private key in your `.ssh` directory, for which you have uploaded the public key to GitHub. The `-F` option can be used to specify a different ssh config file if needed.
 
 ## Hardware Overview
 

--- a/docs/aurora/getting-started-on-aurora.md
+++ b/docs/aurora/getting-started-on-aurora.md
@@ -157,7 +157,7 @@ If you need to use something besides your default SSH key on Aurora for authenti
 export GIT_SSH_COMMAND="ssh -i ~/.ssh/specialGitKey"
 ```
 
-where specialGitKey is the name of the private key in your `.ssh` directory, for which you have uploaded the public key to GitHub. The `-F` option can be used to specify a different ssh config file if needed.
+where specialGitKey is the name of the private key in your `.ssh` directory, for which you have uploaded the public key to GitHub. The `-F` option can be used to specify a different SSH config file if needed; for example, `-F none` will completely ignore your config file, including the above workaround. 
 
 ## Hardware Overview
 


### PR DESCRIPTION
The ssh command in question was copy+paste from the original Sunspot Drupal page. I'm not sure why we'd want to ignore the ssh config file (or set it to /dev/null instead of `none` as indicated in the man page). I updated the command and added a sentence to keep the `-F` info in case of issues.