### PR TITLE
Shift Reservations to Microsoft Form

### DIFF
--- a/docs/running-jobs/machine-reservations.md
+++ b/docs/running-jobs/machine-reservations.md
@@ -2,17 +2,22 @@
 
 To get a reservation, you must first demonstrate a need to run outside of the normal queueing policies. Reservations are available only to projects with a positive allocation. 
 
-Lead time for approval is **5 business days**. If approved, scheduling is contingent on machine availability.
+**5 business day** lead time is recommended to ensure timely approval. Scheduling is contingent on machine availability.
 
 **Disclaimer:** Approval for reservation requests are subject to their appropriateness and machine availability. Not all requests will be approved. It is particularly difficult to accommodate reservation requests during busy times of the year, e.g. Supercomputing, end of the ALCC and INCITE allocation cycles.
 
 **Kindness Policy:** We do monitor reservation utilization. The Scheduling Committee reserves the right to cancel reservations without notice if we decide a reservation is underutilized, not being properly utilized, or otherwise wasting resources. For instance, requesting a 12 hour reservation for interactive work, but then going to lunch leaving the reservation empty with no work.
 
-**Early Completion Policy:** If you have finished running your jobs before your reservation has ended, please reach out to the support team (support@alcf.anl.gov) to have to release it for other users.
-At this time, there is no way for a user to release a reservation early.
+**Early Completion Policy:** If you have finished running your jobs before your reservation has ended, please reach out to the support team (support@alcf.anl.gov) to have to release it for other users. At this time, there is no way for a user to release a reservation early.
+
+
+### Some definitions
+A **reservation** means we set aside some number of nodes on a system for a limited time. Only certain users or projects can submit to the queues assigned to the reservation.
+
+A **score boost** means we give your job(s) a boost in score to help it move ahead in the queue, but it still allows the scheduler to more efficiently fill the machine. 
 
 ----
-### [-> Fill out the Reservation Form <-](https://forms.office.com/Pages/ResponsePage.aspx?id=haH8DPcl40mK53BNUybihXhEiVpWIVZNp8Ow6W1CJnVUNTZLQ1c2N1lSOVNFQkg4RkJTSTAyMUJCNi4u)
+### [-> Fill out the Form <-](https://forms.office.com/Pages/ResponsePage.aspx?id=haH8DPcl40mK53BNUybihXhEiVpWIVZNp8Ow6W1CJnVUNTZLQ1c2N1lSOVNFQkg4RkJTSTAyMUJCNi4u)
 ----
 
 # Querying Reservations via Command Line

--- a/docs/running-jobs/machine-reservations.md
+++ b/docs/running-jobs/machine-reservations.md
@@ -1,57 +1,47 @@
 # Machine Reservations
 
-To get a reservation, you must first demonstrate a need to run outside of the normal queueing policies. Reservations are available only to projects with a positive allocation. Lead time for approval is 5 business days. If approved, scheduling is contingent on machine availability.
+To get a reservation, you must first demonstrate a need to run outside of the normal queueing policies. Reservations are available only to projects with a positive allocation. 
+
+Lead time for approval is **5 business days**. If approved, scheduling is contingent on machine availability.
 
 **Disclaimer:** Approval for reservation requests are subject to their appropriateness and machine availability. Not all requests will be approved. It is particularly difficult to accommodate reservation requests during busy times of the year, e.g. Supercomputing, end of the ALCC and INCITE allocation cycles.
 
-To request a reservation, e-mail [support@alcf.anl.gov](mailto:support@alcf.anl.gov) with the requested information below.
+**Kindness Policy:** We do monitor reservation utilization. The Scheduling Committee reserves the right to cancel reservations without notice if we decide a reservation is underutilized, not being properly utilized, or otherwise wasting resources. For instance, requesting a 12 hour reservation for interactive work, but then going to lunch leaving the reservation empty with no work.
 
-1. RESERVATION REQUEST FOR ALL SYSTEMS (including vis clusters) AT ALCF Machine name:
-2. Project for reservation:
-3. ALCF account username(s) (NOT the user's legal name) for reservation:
+**Early Completion Policy:** If you have finished running your jobs before your reservation has ended, please reach out to the support team (support@alcf.anl.gov) to have to release it for other users.
+At this time, there is no way for a user to release a reservation early.
 
-    *NOTE: We can only gate a reservation on an explicit list of users or a list of groups, we can’t mix them both. So users must specify either a project/unixgroup name or a list of usernames, not both.*
+[Fill out the Reservation Form](https://forms.office.com/Pages/ResponsePage.aspx?id=haH8DPcl40mK53BNUybihXhEiVpWIVZNp8Ow6W1CJnVUNTZLQ1c2N1lSOVNFQkg4RkJTSTAyMUJCNi4u)
 
-4. Length of reservation :
-   
-    *NOTE: If this is a multi-day request, provide the start and end dates along with the start and end times for each day*
+# Querying Reservations via Command Line
 
-6. Earliest date you could start (date and time):
-7. Deadline for the run(s),
-8. Details on the reservation's constraints (can it run anytime, day or night?)
-9. Your local time zone (e.g., US/Central):
-10. Total number of jobs to be run:
-11. Total amount of data generated during reservation:
-12. For each job, indicate: Node count (Note: not processor count)
-    1. Run time whether this job depends on any other jobs to finish before it can start
-    2. Briefly describe the goals for this run: (Example: We are doing a scaling run of code XXXX to determine YYYY)
-    3. Please provide a detailed explanation of why this workload cannot be accomplished with the existing queues: (Requests omitting this response will be not be processed)
-    4. After a reservation is granted, you will receive a reservation name by e-mail. Use the command `pbs_rstat` to verify the reservation attributes.
-
-**For example:**
+You can see reservations using the `pbs_rstat` command:
 
 ```
 pbs_rstat
 Resv ID      Queue     User     State               Start / Duration / End             
 ---------------------------------------------------------------------------
 A123456.po   A123456   smith@   CO       Mon Aug 18 09:00 / 43200 / Tue Aug 19 11:00
-
-qsub -q A123456 walltime=60:00 -l select=1024:system=polaris -l filesystems=eagle myprog.exe
 ```
 
-Once the reservation is set up, jobs can be submitted to the reservation queue prior to the reservation start time.
+For recurring reservations, the `reserve_start` and `reserve_end` are always the first instance. 
+`reserve_index` and `reserve_count` tell you where you are in the recurrence.
 
-For recurring reservations, the ```reserve_start``` and ```reserve_end``` are always the first instance. 
-```reserve_index``` and ```reserve_count``` tell you where you are in the recurrence.
+
+# Using a Reservation
+
+Once the reservation is set up, jobs can be submitted to the reservation queue prior to the reservation start time. In the example above, the queue name is shown in the `Queue` column.
+
+```
+qsub -q A123456 walltime=60:00 -l select=1024:system=polaris -l filesystems=eagle myprog.exe
+```
 
 For jobs using 33 percent or more of a system, place your job in the queue at least 12 hours prior to the start of the reservation or your reservation may be canceled. The machine will start to drain for your reservation, and it is important that your job is ready to run.
 
 You can also move jobs from the regular queue to the reservation queue at any time using the “qmove” command. 
 Keep in mind that a job won't start unless enough time is left in the reservation. 
 
-***NOTE: There is NOT a 10-minute pad at the end of the reservation. 
+***NOTE: There is NOT any padding at the end of the reservation. 
 When the reservation ends all jobs are terminated, deleted, and the reservation queue is deleted. 
 If a routing queue is used for the reservation, then jobs may be preserved, but any running job(s) are still terminated.***
 
-If you have finished running your jobs before your reservation has ended, please reach out to the support team to have to release it for other users.
-At this time, there is no way for a user to release a reservation early.

--- a/docs/running-jobs/machine-reservations.md
+++ b/docs/running-jobs/machine-reservations.md
@@ -11,7 +11,9 @@ Lead time for approval is **5 business days**. If approved, scheduling is contin
 **Early Completion Policy:** If you have finished running your jobs before your reservation has ended, please reach out to the support team (support@alcf.anl.gov) to have to release it for other users.
 At this time, there is no way for a user to release a reservation early.
 
-[Fill out the Reservation Form](https://forms.office.com/Pages/ResponsePage.aspx?id=haH8DPcl40mK53BNUybihXhEiVpWIVZNp8Ow6W1CJnVUNTZLQ1c2N1lSOVNFQkg4RkJTSTAyMUJCNi4u)
+----
+### [-> Fill out the Reservation Form <-](https://forms.office.com/Pages/ResponsePage.aspx?id=haH8DPcl40mK53BNUybihXhEiVpWIVZNp8Ow6W1CJnVUNTZLQ1c2N1lSOVNFQkg4RkJTSTAyMUJCNi4u)
+----
 
 # Querying Reservations via Command Line
 


### PR DESCRIPTION
The scheduling committee is shifting from using a copy & paste into support... to using a proper Microsoft Form for reservations.