### PR TITLE
Fixing typo in environment variable name

### DIFF
--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -16,7 +16,7 @@ As a workaround, the following environment variables can be set to try alleviati
 
 ```bash
 export FI_CXI_DEFAULT_CQ_SIZE=131072
-export FI_CXI_OVFLOW_BUF_SIZE=8388608
+export FI_CXI_OFLOW_BUF_SIZE=8388608
 export FI_CXI_CQ_FILL_PERCENT=20
 ```
 


### PR DESCRIPTION
This fixes a typo in an environment variable. It is not `FI_CX_OVFLOW`, it is `FI_CX_OFLOW`. Thanks to Brian Holland and @nscottnichols !