### PR TITLE
Update python.md

### DIFF
--- a/docs/polaris/data-science-workflows/python.md
+++ b/docs/polaris/data-science-workflows/python.md
@@ -32,8 +32,9 @@ we can build a `venv` on top of it.
     the `base` packaes):
 
     ```bash
-    module load conda; conda activate
-    VENV_DIR="venvs/polaris"
+    module use /soft/modulefiles ; module load conda; conda activate base
+    CONDA_NAME=$(echo ${CONDA_PREFIX} | tr '\/' '\t' | sed -E 's/mconda3|\/base//g' | awk '{print $NF}')
+    VENV_DIR="$(pwd)/venvs/${CONDA_NAME}"
     mkdir -p "${VENV_DIR}"
     python -m venv "${VENV_DIR}" --system-site-packages
     source "${VENV_DIR}/bin/activate"


### PR DESCRIPTION

1. Update the virtual environment instructions to reflect the recent change to loading the default `conda` module, e.g.

    ```diff
    - module load conda
    + module use /soft/modulefiles ; module load conda
    ```

2. Generalize the `"${VENV_DIR}"` work with arbitrary `conda` environments