### PR TITLE
Updating recommended LLVM OpenMP offload flags on Polaris docs

### DIFF
--- a/docs/polaris/compiling-and-linking/polaris-programming-models.md
+++ b/docs/polaris/compiling-and-linking/polaris-programming-models.md
@@ -28,7 +28,7 @@ A summary of available GPU programming models and relevant compiler flags is sho
 | HIP* | -- | -- | -- | -- |
 | OpenACC | -- | -acc | -- | -- |
 | OpenCL* | -- | -- | -- | -- |
-| OpenMP | --| -mp=gpu | -fopenmp-targets=nvptx64 | -- |
+| OpenMP | --| -mp=gpu | -fopenmp-targets=nvptx64 --offload-arch=sm_80 -fopenmp-offload-mandatory | -- |
 | SYCL | -- | -- | -- | -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 |
 
 Note, the `llvm` and `oneapi` modules are provided by ALCF to complement the compilers provided by the Cray PE on Polaris.

--- a/docs/polaris/compiling-and-linking/polaris-programming-models.md
+++ b/docs/polaris/compiling-and-linking/polaris-programming-models.md
@@ -28,7 +28,7 @@ A summary of available GPU programming models and relevant compiler flags is sho
 | HIP* | -- | -- | -- | -- |
 | OpenACC | -- | -acc | -- | -- |
 | OpenCL* | -- | -- | -- | -- |
-| OpenMP | --| -mp=gpu | -fopenmp-targets=nvptx64 --offload-arch=sm_80 | -- |
+| OpenMP | --| -mp=gpu | --offload-arch=sm_80 | -- |
 | SYCL | -- | -- | -- | -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 |
 
 Note, the `llvm` and `oneapi` modules are provided by ALCF to complement the compilers provided by the Cray PE on Polaris.

--- a/docs/polaris/compiling-and-linking/polaris-programming-models.md
+++ b/docs/polaris/compiling-and-linking/polaris-programming-models.md
@@ -28,7 +28,7 @@ A summary of available GPU programming models and relevant compiler flags is sho
 | HIP* | -- | -- | -- | -- |
 | OpenACC | -- | -acc | -- | -- |
 | OpenCL* | -- | -- | -- | -- |
-| OpenMP | --| -mp=gpu | -fopenmp-targets=nvptx64 --offload-arch=sm_80 -fopenmp-offload-mandatory | -- |
+| OpenMP | --| -mp=gpu | -fopenmp-targets=nvptx64 --offload-arch=sm_80 | -- |
 | SYCL | -- | -- | -- | -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 |
 
 Note, the `llvm` and `oneapi` modules are provided by ALCF to complement the compilers provided by the Cray PE on Polaris.

--- a/docs/polaris/programming-models/openmp-polaris.md
+++ b/docs/polaris/programming-models/openmp-polaris.md
@@ -75,7 +75,7 @@ The following table shows what compiler and flags to use with which PrgEnv:
 |module | compiler | flags
 | --- | --- | --- |
 | PrgEnv-nvhpc | cc/CC/ftn (nvc/nvc++/nvfortran) | -mp=gpu -gpu=cc80 | 
-| llvm | mpicc/mpicxx (clang/clang++) | -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda | 
+| llvm | mpicc/mpicxx (clang/clang++) | -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 -fopenmp-offload-mandatory | 
 | PrgEnv-gnu | cc/CC/ftn (gcc/g++/gfortran) | -fopenmp |
 | PrgEnv-cray | cc/CC/ftn | -fopenmp |
 
@@ -91,7 +91,7 @@ ftn -mp=gpu -gpu=cc80 hello.F90
 ### For LLVM, after loading the modules as discussed above:
 
 ```
-mpicxx -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda hello.cpp 
+mpicxx -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 -fopenmp-offload-mandatory hello.cpp 
 ```
 
 ### For PrgEnv-gnu, after loading the modules as discussed above we would use:

--- a/docs/polaris/programming-models/openmp-polaris.md
+++ b/docs/polaris/programming-models/openmp-polaris.md
@@ -75,7 +75,7 @@ The following table shows what compiler and flags to use with which PrgEnv:
 |module | compiler | flags
 | --- | --- | --- |
 | PrgEnv-nvhpc | cc/CC/ftn (nvc/nvc++/nvfortran) | -mp=gpu -gpu=cc80 | 
-| llvm | mpicc/mpicxx (clang/clang++) | -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 -fopenmp-offload-mandatory | 
+| llvm | mpicc/mpicxx (clang/clang++) | -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 | 
 | PrgEnv-gnu | cc/CC/ftn (gcc/g++/gfortran) | -fopenmp |
 | PrgEnv-cray | cc/CC/ftn | -fopenmp |
 
@@ -91,7 +91,7 @@ ftn -mp=gpu -gpu=cc80 hello.F90
 ### For LLVM, after loading the modules as discussed above:
 
 ```
-mpicxx -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 -fopenmp-offload-mandatory hello.cpp 
+mpicxx -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 hello.cpp 
 ```
 
 ### For PrgEnv-gnu, after loading the modules as discussed above we would use:

--- a/docs/polaris/programming-models/openmp-polaris.md
+++ b/docs/polaris/programming-models/openmp-polaris.md
@@ -94,6 +94,10 @@ ftn -mp=gpu -gpu=cc80 hello.F90
 mpicxx -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 hello.cpp 
 ```
 
+Note that if you want to force the code to error out if it cannot run on
+the GPU (instead of falling back to run on host, which is the default), you can
+additionally compile with `-fopenmp-offload-mandatory`.
+
 ### For PrgEnv-gnu, after loading the modules as discussed above we would use:
 
 ```

--- a/docs/polaris/programming-models/openmp-polaris.md
+++ b/docs/polaris/programming-models/openmp-polaris.md
@@ -75,7 +75,7 @@ The following table shows what compiler and flags to use with which PrgEnv:
 |module | compiler | flags
 | --- | --- | --- |
 | PrgEnv-nvhpc | cc/CC/ftn (nvc/nvc++/nvfortran) | -mp=gpu -gpu=cc80 | 
-| llvm | mpicc/mpicxx (clang/clang++) | -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 | 
+| llvm | mpicc/mpicxx (clang/clang++) | -fopenmp --offload-arch=sm_80 | 
 | PrgEnv-gnu | cc/CC/ftn (gcc/g++/gfortran) | -fopenmp |
 | PrgEnv-cray | cc/CC/ftn | -fopenmp |
 
@@ -91,7 +91,7 @@ ftn -mp=gpu -gpu=cc80 hello.F90
 ### For LLVM, after loading the modules as discussed above:
 
 ```
-mpicxx -fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --offload-arch=sm_80 hello.cpp 
+mpicxx -fopenmp --offload-arch=sm_80 hello.cpp 
 ```
 
 Note that if you want to force the code to error out if it cannot run on


### PR DESCRIPTION
This updates the LLVM OpenMP flags recommended on Polaris. The reason is that some people compile on the logins, and the GPU architecture may not get pulled in if it's compiled on the logins. @adrianpope saw this with an OpenMP code measuring peak flop rate. (All credit to Adrian for this fix :) )    