### PR TITLE
Update running-a-model-or-program.md

### DIFF
--- a/docs/ai-testbed/graphcore/running-a-model-or-program.md
+++ b/docs/ai-testbed/graphcore/running-a-model-or-program.md
@@ -16,6 +16,7 @@ mkdir ~/graphcore
 cd ~/graphcore
 git clone https://github.com/graphcore/examples.git
 cd examples
+git checkout v3.3.0
 ```
 
 ### MNIST


### PR DESCRIPTION
add an update to the example to explicitly show `git checkout v3.3.0` as an upstream dep change will break the pip step.

```
Collecting networkx
  Using cached https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl (1.6 MB)
ERROR: Package 'networkx' requires a different Python: 3.8.10 not in '>=3.9'
```