### PR TITLE
Add XALT docs for Polaris

### DIFF
--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -19,5 +19,5 @@ When xalt is enabled during application executions:
 - XALT interposes a LD_PRELOAD library into the execution of the user's application. XALT runs as the user, with the user's primary and supplementary groups
 
 ## How to disable XALT
-- Execute the command "module unload xalt"
+- Execute the command `module unload xalt`
 - If you disable xalt please send email to [support@alcf.anl.gov](mailto:support@alcf.anl.gov) detailing the reason you are disabling it

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -1,0 +1,23 @@
+# XALT
+
+## What is XALT?
+
+XALT is a user build and execution tracking framework; it is installed at ALCF on Polaris to track library usage.
+
+When xalt is enabled during builds:
+- An xalt watermark is added to the elf binary of the executable(s)
+- An xalt link record containing information about the build is created
+  
+When xalt is enabled during application executions:
+- An xalt start run record containing information about the execution is created; some link data is also included if the executable was built with xalt
+- If the execution exits normally, an xalt end run record containing information about the end of the process is created; if the process exits abnormally no end run record is created
+- For mpi jobs, xalt run records are produced only for rank 0
+
+## XALT implementation details
+
+- XALT uses an ld wrapper script to add the watermark to executables
+- XALT interposes a LD_PRELOAD library into the execution of the user's application. XALT runs as the user, with the user's primary and supplementary groups
+
+## How to disable XALT
+- Execute the command "module unload xalt"
+- If you disable xalt please send email to support@alcf.anl.gov detailing the reason you are disabling it

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -20,4 +20,4 @@ When xalt is enabled during application executions:
 
 ## How to disable XALT
 - Execute the command "module unload xalt"
-- If you disable xalt please send email to support@alcf.anl.gov detailing the reason you are disabling it
+- If you disable xalt please send email to [support@alcf.anl.gov](mailto:support@alcf.anl.gov) detailing the reason you are disabling it

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -15,7 +15,7 @@ When XALT is enabled during application executions:
 
 ## XALT implementation details
 
-- XALT uses an`ld` wrapper script to add the watermark to executables
+- XALT uses an `ld` wrapper script to add the watermark to executables
 - XALT interposes a `LD_PRELOAD` library into the execution of the user's application. XALT runs as the user, with the user's primary and supplementary groups
 
 ## How to disable XALT

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -10,7 +10,7 @@ When xalt is enabled during builds:
   
 When XALT is enabled during application executions:
 - An xalt start run record containing information about the execution is created; some link data is also included if the executable was built with xalt
-- If the execution exits normally, an xalt end run record containing information about the end of the process is created; if the process exits abnormally no end run record is created
+- If the execution exits normally, an XALT end run record containing information about the end of the process is created; if the process exits abnormally no end run record is created
 - For MPI jobs, XALT run records are produced only for rank 0
 
 ## XALT implementation details

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -16,7 +16,7 @@ When xalt is enabled during application executions:
 ## XALT implementation details
 
 - XALT uses an`ld` wrapper script to add the watermark to executables
-- XALT interposes a LD_PRELOAD library into the execution of the user's application. XALT runs as the user, with the user's primary and supplementary groups
+- XALT interposes a `LD_PRELOAD` library into the execution of the user's application. XALT runs as the user, with the user's primary and supplementary groups
 
 ## How to disable XALT
 - Execute the command `module unload xalt`

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -9,7 +9,7 @@ When xalt is enabled during builds:
 - An XALT link record containing information about the build is created
   
 When XALT is enabled during application executions:
-- An xalt start run record containing information about the execution is created; some link data is also included if the executable was built with xalt
+- An XALT start run record containing information about the execution is created; some link data is also included if the executable was built with XALT
 - If the execution exits normally, an XALT end run record containing information about the end of the process is created; if the process exits abnormally no end run record is created
 - For MPI jobs, XALT run records are produced only for rank 0
 

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -5,7 +5,7 @@
 XALT is a user build and execution tracking framework; it is installed at ALCF on Polaris to track library usage.
 
 When xalt is enabled during builds:
-- An xalt watermark is added to the elf binary of the executable(s)
+- An XALT watermark is added to the ELF binary of the executable(s)
 - An xalt link record containing information about the build is created
   
 When XALT is enabled during application executions:

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -11,7 +11,7 @@ When xalt is enabled during builds:
 When XALT is enabled during application executions:
 - An xalt start run record containing information about the execution is created; some link data is also included if the executable was built with xalt
 - If the execution exits normally, an xalt end run record containing information about the end of the process is created; if the process exits abnormally no end run record is created
-- For mpi jobs, xalt run records are produced only for rank 0
+- For MPI jobs, XALT run records are produced only for rank 0
 
 ## XALT implementation details
 

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -8,7 +8,7 @@ When xalt is enabled during builds:
 - An xalt watermark is added to the elf binary of the executable(s)
 - An xalt link record containing information about the build is created
   
-When xalt is enabled during application executions:
+When XALT is enabled during application executions:
 - An xalt start run record containing information about the execution is created; some link data is also included if the executable was built with xalt
 - If the execution exits normally, an xalt end run record containing information about the end of the process is created; if the process exits abnormally no end run record is created
 - For mpi jobs, xalt run records are produced only for rank 0

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -15,7 +15,7 @@ When xalt is enabled during application executions:
 
 ## XALT implementation details
 
-- XALT uses an ld wrapper script to add the watermark to executables
+- XALT uses an`ld` wrapper script to add the watermark to executables
 - XALT interposes a LD_PRELOAD library into the execution of the user's application. XALT runs as the user, with the user's primary and supplementary groups
 
 ## How to disable XALT

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -4,7 +4,7 @@
 
 XALT is a user build and execution tracking framework; it is installed at ALCF on Polaris to track library usage.
 
-When xalt is enabled during builds:
+When XALT is enabled during builds:
 - An XALT watermark is added to the ELF binary of the executable(s)
 - An XALT link record containing information about the build is created
   

--- a/docs/polaris/applications-and-libraries/libraries/xalt.md
+++ b/docs/polaris/applications-and-libraries/libraries/xalt.md
@@ -6,7 +6,7 @@ XALT is a user build and execution tracking framework; it is installed at ALCF o
 
 When xalt is enabled during builds:
 - An XALT watermark is added to the ELF binary of the executable(s)
-- An xalt link record containing information about the build is created
+- An XALT link record containing information about the build is created
   
 When XALT is enabled during application executions:
 - An xalt start run record containing information about the execution is created; some link data is also included if the executable was built with xalt

--- a/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
+++ b/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
@@ -72,7 +72,7 @@ Dynamic linking of libraries is currently the default on Polaris. The Cray MPI w
 
 * `craype-accel-nvidia80`: This module adds compiler flags to enable GPU acceleration for `NVHPC` compilers along with gpu-enabled MPI libraries as it is assumed that the majority of applications to be compiled on Polaris will target the GPUs for acceleration. Users building cpu-only applications may find it useful to unload this module to silence "gpu code generation" warnings.
 
-* `xalt`: This module enables library tracking; it helps ALCF identify software important to our users. More information on XALT can be found here: ?
+* `xalt`: This module enables library tracking; it helps ALCF identify software important to our users. More information can be found on the [XALT](./applications-and-libraries/libraries/xalt.md) page.
 
 ## Mixed C/C++ & Fortran Applications
 

--- a/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
+++ b/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
@@ -72,7 +72,7 @@ Dynamic linking of libraries is currently the default on Polaris. The Cray MPI w
 
 * `craype-accel-nvidia80`: This module adds compiler flags to enable GPU acceleration for `NVHPC` compilers along with gpu-enabled MPI libraries as it is assumed that the majority of applications to be compiled on Polaris will target the GPUs for acceleration. Users building cpu-only applications may find it useful to unload this module to silence "gpu code generation" warnings.
 
-* `xalt`: This module enables library tracking; it helps ALCF identify software important to our users. More information can be found on the [XALT](./applications-and-libraries/libraries/xalt.md) page.
+* `xalt`: This module enables library tracking; it helps ALCF identify software important to our users. More information can be found on the [XALT](../applications-and-libraries/libraries/xalt.md) page.
 
 ## Mixed C/C++ & Fortran Applications
 

--- a/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
+++ b/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
@@ -72,7 +72,7 @@ Dynamic linking of libraries is currently the default on Polaris. The Cray MPI w
 
 * `craype-accel-nvidia80`: This module adds compiler flags to enable GPU acceleration for `NVHPC` compilers along with gpu-enabled MPI libraries as it is assumed that the majority of applications to be compiled on Polaris will target the GPUs for acceleration. Users building cpu-only applications may find it useful to unload this module to silence "gpu code generation" warnings.
 
-* `xalt`: This module enables library tracking, which helps ALCF identify software important to our users. More information on XALT can be found here: ?
+* `xalt`: This module enables library tracking; it helps ALCF identify software important to our users. More information on XALT can be found here: ?
 
 ## Mixed C/C++ & Fortran Applications
 

--- a/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
+++ b/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
@@ -72,6 +72,8 @@ Dynamic linking of libraries is currently the default on Polaris. The Cray MPI w
 
 * `craype-accel-nvidia80`: This module adds compiler flags to enable GPU acceleration for `NVHPC` compilers along with gpu-enabled MPI libraries as it is assumed that the majority of applications to be compiled on Polaris will target the GPUs for acceleration. Users building cpu-only applications may find it useful to unload this module to silence "gpu code generation" warnings.
 
+* `xalt`: This module enables library tracking. More information on XALT can be found here: ?
+
 ## Mixed C/C++ & Fortran Applications
 
 For applications consisting of a mix of C/C++ and Fortran that also uses MPI, it is suggested that the programming environment chosen for Fortran be used to build the full application because of mpi.mod (and similar) incompatibilities. 

--- a/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
+++ b/docs/polaris/compiling-and-linking/compiling-and-linking-overview.md
@@ -72,7 +72,7 @@ Dynamic linking of libraries is currently the default on Polaris. The Cray MPI w
 
 * `craype-accel-nvidia80`: This module adds compiler flags to enable GPU acceleration for `NVHPC` compilers along with gpu-enabled MPI libraries as it is assumed that the majority of applications to be compiled on Polaris will target the GPUs for acceleration. Users building cpu-only applications may find it useful to unload this module to silence "gpu code generation" warnings.
 
-* `xalt`: This module enables library tracking. More information on XALT can be found here: ?
+* `xalt`: This module enables library tracking, which helps ALCF identify software important to our users. More information on XALT can be found here: ?
 
 ## Mixed C/C++ & Fortran Applications
 

--- a/docs/polaris/system-updates.md
+++ b/docs/polaris/system-updates.md
@@ -1,6 +1,6 @@
 # Polaris System Updates
 
-## 2024-09-11
+## 2024-09-09
 
 ### XALT
 The XALT library tracking software has been enabled for all Polaris users. More information on the Polaris XALT deployment can be found here: ?

--- a/docs/polaris/system-updates.md
+++ b/docs/polaris/system-updates.md
@@ -3,7 +3,7 @@
 ## 2024-09-09
 
 ### XALT
-The XALT library tracking software has been enabled for all Polaris users. More information on the Polaris XALT deployment can be found here: ?
+The XALT library tracking software has been enabled for all Polaris users. More information can be found on the [XALT](./applications-and-libraries/libraries/xalt.md) page.
 
 ## 2024-04-22
 

--- a/docs/polaris/system-updates.md
+++ b/docs/polaris/system-updates.md
@@ -1,9 +1,9 @@
 # Polaris System Updates
 
-## 2024-09-09
+## 2024-09-11
 
 ### XALT
-The library tracking software XALT has been enabled for all Polaris users.
+The XALT library tracking software has been enabled for all Polaris users. More information on the Polaris XALT deployment can be found here: ?
 
 ## 2024-04-22
 

--- a/docs/polaris/system-updates.md
+++ b/docs/polaris/system-updates.md
@@ -1,5 +1,10 @@
 # Polaris System Updates
 
+## 2024-09-09
+
+### XALT
+The library tracking software XALT has been enabled for all Polaris users.
+
 ## 2024-04-22
 
 The management software on Polaris has been upgraded to HPCM 1.10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
             - Math Libraries: polaris/applications-and-libraries/libraries/math-libraries.md
             - Cabana: polaris/applications-and-libraries/libraries/cabana-polaris.md
             - Spack PE: polaris/applications-and-libraries/libraries/spack-pe.md
+            - XALT: polaris/applications-and-libraries/libraries/xalt.md
     - Data Science:
         - Julia: polaris/data-science-workflows/julia.md
         - Python: polaris/data-science-workflows/python.md


### PR DESCRIPTION
This is a proposed foundation for Polaris XALT docs, which will be enabled for all Polaris users after the 9/9-10 maintenance. I intend to review all xalt support tickets and add to the /polaris/known-issues/ page as problems are identified. I also intend to add a Troubleshooting section to the main xalt page.

Happy to add more info on xalt or make changes to the xalt doc hierarchy as appropriate. This is my first PR for ALCF docs.