### PR TITLE
Update openmp-polaris.md

### DIFF
--- a/docs/polaris/programming-models/openmp-polaris.md
+++ b/docs/polaris/programming-models/openmp-polaris.md
@@ -28,6 +28,7 @@ This is loaded by default, so there's no need to load additional modules. You ca
 
 To use the LLVM module, load the following.
 ```
+module use /soft/modulefiles
 module load mpiwrappers/cray-mpich-llvm
 module load cudatoolkit-standalone
 ```


### PR DESCRIPTION
This updates the OpenMP docs to add a line that we need to `module use /soft/modulefiles` before using LLVM compiler.