### PR TITLE
updates to kokkos and cabana pages to reflect new software environment

### DIFF
--- a/docs/aurora/applications-and-libraries/libraries/cabana-aurora.md
+++ b/docs/aurora/applications-and-libraries/libraries/cabana-aurora.md
@@ -17,7 +17,6 @@ backends: Serial and OpenMP for CPU execution and SYCL for GPU execution. To
 use it, run
 
 ```
-module use /soft/modulefiles
 module load cabana
 ```
 


### PR DESCRIPTION
update to remove obsolete references to /soft/modulefiles, use newer compiler/linker flags, replace some copy/paste leftovers referring to CUDA, and fix odds and ends