### PR TITLE
Proofread Crux docs with Argo/GPT4o

### DIFF
--- a/docs/crux/compiling-and-linking/compiling-and-linking-overview.md
+++ b/docs/crux/compiling-and-linking/compiling-and-linking-overview.md
@@ -1,14 +1,11 @@
 # Compiling and Linking on Crux
 
 ## Overview
-Crux has AMD processors on the login nodes (crux-login-01,02) and AMD
-processors on the compute nodes (see [Machine
-Overview](../hardware-overview/machine-overview.md) page). The login nodes can
-be used to compile software, create containers, and launch jobs. For larger, parallel builds, it will be beneficial to compile those directly on the compute nodes.
+Crux has AMD processors on the login nodes (crux-login-01,02) and AMD processors on the compute nodes (see [Machine Overview](../hardware-overview/machine-overview.md) page). The login nodes can be used to compile software, create containers, and launch jobs. For larger, parallel builds, it will be beneficial to compile those directly on the compute nodes.
 
-To launch an interactive job and acquire a compute node for compiling, use
+To launch an interactive job and acquire a compute node for compiling, use:
 
-```
+```bash
 qsub -I -q workq -A myProjectShortName -n 1 -t HH:MM:SS
 ```
 
@@ -18,25 +15,30 @@ The default programming environment on the Crux compute nodes is currently Cray:
 - `CC` - C++ compiler
 - `ftn` - Fortran compiler
 
-Each of these wrappers will select the corresponding vendor compiler based on the PrgEnv module loaded in the environment. The following are some helpful options to understand what the compiler wrapper is invoking.
+Each of these wrappers will select the corresponding vendor compiler based on the PrgEnv module loaded in the environment. The following are some helpful options to understand what the compiler wrapper is invoking:
 
-- `--craype-verbose` : Print the command which is forwarded to the compiler invocation
-- `--cray-print-opts=libs` : Print library information
-- `--cray-print-opts=cflags` : Print include information
+- `--craype-verbose`: Print the command which is forwarded to the compiler invocation
+- `--cray-print-opts=libs`: Print library information
+- `--cray-print-opts=cflags`: Print include information
 
 Further documentation and options are available via `man cc` and similar.
 
 ## Modules on Crux
 
 Available modules can be listed via the command:
-```
+
+```bash
 module avail
 ```
+
 Loaded modules in your environment can be listed via the command:
-```
+
+```bash
 module list
 ```
-To load new modules use:
-```
+
+To load new modules, use:
+
+```bash
 module load <module_name>
 ```

--- a/docs/crux/containers/containers.md
+++ b/docs/crux/containers/containers.md
@@ -1,5 +1,5 @@
 # Containers on Crux
 
 Apptainer will be supported on Crux at a future date.
- 
+
 --8<-- "./docs/polaris/containers/containers.md:commoncontainerdoc"

--- a/docs/crux/data-science/python.md
+++ b/docs/crux/data-science/python.md
@@ -1,8 +1,6 @@
 # Python
 
-At a future date, we will provide prebuilt `conda` environments containing CPU-optimized
-builds `torch`, `tensorflow` (both with `horovod` support for multi-node calculations),
-`jax`, and many other commonly-used Python modules.
+At a future date, we will provide prebuilt `conda` environments containing CPU-optimized builds of `torch`, `tensorflow` (both with `horovod` support for multi-node calculations), `jax`, and many other commonly used Python modules.
 
 In the meantime, users should be able to create their own local environments to begin work on Crux. In this example, `mpi4py` is installed.
 

--- a/docs/crux/getting-started.md
+++ b/docs/crux/getting-started.md
@@ -3,30 +3,28 @@
 ## Logging Into Crux
 
 To log into Crux:
-```
+```bash
 ssh <username>@crux.alcf.anl.gov
 ```
-Then, type in the password from your CRYPTOCard/MobilePASS+ token. Once logged
-in, you land on one of the crux login nodes (`crux-login-01`, `crux-login-02`). 
+Then, type in the password from your CRYPTOCard/MobilePASS+ token. Once logged in, you land on one of the Crux login nodes (`crux-login-01`, `crux-login-02`).
 
 ## Hardware Overview
 
-An overview of the Crux system including details on the compute node architecture is available on the [Machine Overview](./hardware-overview/machine-overview.md) page.
+An overview of the Crux system, including details on the compute node architecture, is available on the [Machine Overview](./hardware-overview/machine-overview.md) page.
 
 ## Compiling Applications
 
-For all code building and development please use crux compute nodes, especially for large parallel builds. Please read through the [Compiling and Linking Overview](./compiling-and-linking/compiling-and-linking-overview.md) page and corresponding pages depending on the target compiler and programming model.
+For all code building and development, please use Crux compute nodes, especially for large parallel builds. Please read through the [Compiling and Linking Overview](./compiling-and-linking/compiling-and-linking-overview.md) page and corresponding pages depending on the target compiler and programming model.
 
 ## Accessing Additional Software
 
-ALCF installs additional software in `/soft` which can be accessed via module
-commands by altering your `$MODULEPATH`:
-```
+ALCF installs additional software in `/soft`, which can be accessed via module commands by altering your `$MODULEPATH`:
+```bash
 module use /soft/modulefiles
 ```
-The available software can then be queried with `module avail`. In particular, loading the `spack-pe-base` module provides access to additional software and build tools. For example, `cmake` is available via the following.
+The available software can then be queried with `module avail`. In particular, loading the `spack-pe-base` module provides access to additional software and build tools. For example, `cmake` is available via the following:
 
-```
+```bash
 module use /soft/modulefiles
 module load spack-pe-base
 module load cmake
@@ -36,19 +34,17 @@ module load cmake
 
 Please read through the [Running Jobs with PBS at the ALCF](../running-jobs/job-and-queue-scheduling.md) page for information on using the PBS scheduler and preparing job submission scripts.
 
-For more information on Crux queues and job submission visit: [Running Jobs
-on Crux](./queueing-and-running-jobs/running-jobs.md)
-
+For more information on Crux queues and job submission, visit: [Running Jobs on Crux](./queueing-and-running-jobs/running-jobs.md).
 
 ## Lustre File Striping
 
-In addition to the content above, here is a document on Lustre File Striping Basics. 
+In addition to the content above, here is a document on Lustre File Striping Basics:
 
 - [Lustre File Striping Basics](https://www.alcf.anl.gov/support-center/training-assets/file-systems-and-io-performance)
 
 ## Proxy
 
-If the node you are on doesn’t have outbound network connectivity, add the following to your `~/.bash_profile` file to access the proxy host
+If the node you are on doesn’t have outbound network connectivity, add the following to your `~/.bash_profile` file to access the proxy host:
 
 ```bash
 # proxy settings
@@ -59,7 +55,6 @@ export https_proxy="http://proxy.alcf.anl.gov:3128"
 export ftp_proxy="http://proxy.alcf.anl.gov:3128"
 ```
 <!-- export no_proxy="admin,polaris-adminvm-01,localhost,*.cm.polaris.alcf.anl.gov,polaris-*,*.polaris.alcf.anl.gov,*.alcf.anl.gov" -->
-
 
 <!-- ## MPI -->
 <!-- ALCF provides a few MPI package built specifically for ThetaGPU -->
@@ -76,3 +71,6 @@ export ftp_proxy="http://proxy.alcf.anl.gov:3128"
 ## Getting Assistance
 
 Please direct all questions, requests, and feedback to [support@alcf.anl.gov](mailto:support@alcf.anl.gov).
+
+---
+---

--- a/docs/crux/hardware-overview/machine-overview.md
+++ b/docs/crux/hardware-overview/machine-overview.md
@@ -1,6 +1,6 @@
 # Crux Machine Overview
 
-Crux is an HPE Cray Ex Liquid Cooled system with peak performance of 1.18 PF comprised of 64 compute blades connected via Slingshot. Each blade has 4 compute nodes for a total of 256 nodes in the system. Each compute node has dual AMD EPYC 7742 64-Core Processors. Each CPU core supports up to two hyperthreads for a total of 256 threads possible per node. Each CPU has 128 GB of DDR4 memory for a total of 256 GB per node. 
+Crux is an HPE Cray EX Liquid Cooled system with a peak performance of 1.18 PF, comprised of 64 compute blades connected via Slingshot. Each blade has 4 compute nodes for a total of 256 nodes in the system. Each compute node has dual AMD EPYC 7742 64-Core Processors. Each CPU core supports up to two hyperthreads for a total of 256 threads possible per node. Each CPU has 128 GB of DDR4 memory for a total of 256 GB per node.
 
 # Node Architecture
 
@@ -8,17 +8,17 @@ The output of `numactl --hardware` is very helpful in understanding the connecti
 
 For CPU 0:
 
-* NUMA 0 : cores 0-15,128-143
-* NUMA 1 : cores 16-31,144-159
-* NUMA 2 : cores 32-47,160-175
-* NUMA 3 : cores 48-63,176-191
+* NUMA 0: cores 0-15,128-143
+* NUMA 1: cores 16-31,144-159
+* NUMA 2: cores 32-47,160-175
+* NUMA 3: cores 48-63,176-191
 
 For CPU 1:
 
-* NUMA 4 : cores 64-79,192-207
-* NUMA 5 : cores 80-95,208-223
-* NUMA 6 : cores 96-111,224-239
-* NUMA 7 : cores 112-127,240-255
+* NUMA 4: cores 64-79,192-207
+* NUMA 5: cores 80-95,208-223
+* NUMA 6: cores 96-111,224-239
+* NUMA 7: cores 112-127,240-255
 
 <!-- Table 1 summarizes the capabilities of a Crux compute node:
 
@@ -33,4 +33,3 @@ For CPU 1:
 | 100GbE Ports | 2 | 48 |
 | 3.84 TB Gen4 NVME drives | 4 | 96 |
 -->
-

--- a/docs/crux/queueing-and-running-jobs/running-jobs.md
+++ b/docs/crux/queueing-and-running-jobs/running-jobs.md
@@ -9,7 +9,7 @@ There are five production queues you can target in your qsub (`-q <queue name>`)
 | Queue Name    | Node Min | Node Max | Time Min | Time Max | Notes                                                                                                |
 |---------------|----------|----------|----------|----------|------------------------------------------------------------------------------------------------------|
 | debug         | 1        | 4        | 5 min    | 2 hr     | max 8 nodes in use by this queue at any given time; Only 8 nodes are exclusive (see **Note** below) |
-| workq-route   | 1       | 512      | 5 min    | 24 hrs   | Routing queue; 100 jobs max per project; See below                                                                             |                        |
+| workq-route   | 1        | 512      | 5 min    | 24 hrs   | Routing queue; 100 jobs max per project; See below                                                                             |
 
 ******
 
@@ -19,8 +19,7 @@ There are five production queues you can target in your qsub (`-q <queue name>`)
 
 | Queue Name      | Node Min | Node Max | Time Min | Time Max | Notes                                  |
 |-----------------|----------|----------|----------|----------|----------------------------------------|
-| workq           | 1        | 512      | 5 min    | 24 hrs   | 20 jobs queue or running/10 jobs running per project
-
+| workq           | 1        | 512      | 5 min    | 24 hrs   | 20 jobs queue or running/10 jobs running per project |
 
 ## Running MPI+OpenMP Applications
 
@@ -36,7 +35,7 @@ Once a submitted job is running, calculations can be launched on the compute nod
 * `--hostfile` indicate file with hostnames (the default is `--hostfile $PBS_NODEFILE`)
 
 A sample submission script with directives is below for a 4-node job with 8 MPI ranks on each node and 8 OpenMP threads per rank. Each hardware thread runs a single OpenMP thread since there are 64 hardware threads on the CPU (2 per core).
-You can download and compile `hello_affinity` from this [link](https://github.com/argonne-lcf/GettingStarted/tree/master/Examples/Polaris/affinity).
+You can download and compile `hello_affinity` from this [link](https://github.com/argonne-lcf/GettingStarted/tree/master/Examples/Crux/affinity).
 
 ```bash
 #!/bin/bash -l
@@ -73,9 +72,9 @@ The [`hello_affinity`](https://github.com/argonne-lcf/GettingStarted/tree/master
 
 ## Running Multiple MPI Applications on a Single Node
 
-Multiple applications can be run simultaneously on a node by launching several `mpiexec` commands and backgrounding them. For performance, it will likely be necessary to ensure that each application runs on a distinct set of CPU resources. One can provide a list of CPUs using the `--cpu-bind` option to explicitly assign CPU resources on a node to each application. Output from the `numactl --hardware` command is useful for understanding how to localize applications within NUMA domains on the two CPUs of each node. 
+Multiple applications can be run simultaneously on a node by launching several `mpiexec` commands and backgrounding them. For performance, it will likely be necessary to ensure that each application runs on a distinct set of CPU resources. One can provide a list of CPUs using the `--cpu-bind` option to explicitly assign CPU resources on a node to each application. Output from the `numactl --hardware` command is useful for understanding how to localize applications within NUMA domains on the two CPUs of each node.
 
-In the example below, eight instances of the application are simultaneously running on a single node, with each application localized to a single NUMA domain. Each application here is bound to 16 CPU cores with a single process running on each core (i.e. no hyperthreads). In the first instance, the application is spawning 16 MPI ranks on cores 0-15 in the first CPU. 
+In the example below, eight instances of the application are simultaneously running on a single node, with each application localized to a single NUMA domain. Each application here is bound to 16 CPU cores with a single process running on each core (i.e. no hyperthreads). In the first instance, the application is spawning 16 MPI ranks on cores 0-15 in the first CPU.
 
 ```bash
   MPI_ARG="-n ${NTOTRANKS} --ppn ${NRANKS_PER_NODE}"
@@ -96,9 +95,9 @@ In the example below, eight instances of the application are simultaneously runn
 wait
 ```
 
-## Running Multiple MPI Applications on a Multiple Nodes
+## Running Multiple MPI Applications on Multiple Nodes
 
-An important detail missing from the prior example was specifying the hostfile. When not specified, the default hostfile ${PBS_NODEFILE} is used for all innvocations of `mpiexec` meaning all applications will include identical sets of nodes. This is fine for single-node jobs, but appropriate hostfiles need to be created and passed to `mpiexec` when running applications across subsets of nodes in a large job.
+An important detail missing from the prior example was specifying the hostfile. When not specified, the default hostfile ${PBS_NODEFILE} is used for all invocations of `mpiexec`, meaning all applications will include identical sets of nodes. This is fine for single-node jobs, but appropriate hostfiles need to be created and passed to `mpiexec` when running applications across subsets of nodes in a large job.
 
 The following example first splits the hostfile ${PBS_NODEFILE} into separate hostfiles each containing the requested number of nodes (in this case just 1 per file). The separate hostfiles are then used in each batch of `mpiexec` calls to launch applications on different compute nodes.
 


### PR DESCRIPTION
Continuing with using Argo/GPT4o to improve our documentation. See discussion in #504. Eventually, we can do this with a GitHub action for better automation. The problem with GitHub action is the requirement for an OpenAI key. We can also try free LLMs, but performance might not be as good. Alternative is to have a GitLab mirror and run the action on our machines with Argo.


