### PR TITLE
Reorganize sidebar in `mkdocs.yml`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,302 +1,7 @@
 site_name: ALCF User Guides
-nav:
-  - Home: index.md
-  - Account and Project Management:
-    - Accounts and Access: account-project-management/accounts-and-access/user-account-overview.md
-    - Passcode Tokens: account-project-management/accounts-and-access/alcf-passcode-tokens.md
-    - Accounts and Access FAQs: account-project-management/accounts-and-access/accounts-and-access-faqs.md
-    - Project Management:
-      - Starting Your ALCF Award: account-project-management/project-management/starting-alcf-award.md
-      - Managing Your Team Members: account-project-management/project-management/team-management.md
-      - Reporting: account-project-management/project-management/project-reports.md
-    - Allocations:
-      - Allocations on ALCF Computing Resources: account-project-management/allocation-management/overview.md
-      - Managing Your Allocations: account-project-management/allocation-management/allocation-management.md
-      - sbank Allocation Accounting System: account-project-management/allocation-management/sbank-allocation-accounting-system.md
-  - Data Management:
-    - ALCF Community Data Co-Op: data-management/acdc/acdc-overview.md
-    - Sharing on Eagle Using Globus: data-management/acdc/eagle-data-sharing.md
-    - Transferring Data to Eagle: data-management/acdc/transferring-data-to-eagle.md
-    - Data Transfer:
-      - SFTP and SCP: data-management/data-transfer/sftp-scp.md
-      - Using Globus: data-management/data-transfer/using-globus.md
-    - File System & Storage:
-      - File Systems: data-management/filesystem-and-storage/file-systems.md
-      - Data Storage: data-management/filesystem-and-storage/data-storage.md
-      - HPSS: data-management/filesystem-and-storage/hpss.md
-      - Disk Quota: data-management/filesystem-and-storage/disk-quota.md
-  - Services: # services/index.md  # Cant directly link to this in the nav sidebar, since
-    # it is a dropdown. Only linked to in base docs/index.md
-    - Getting Started: services/getting-started.md
-    - JupyterHub: services/jupyter-hub.md
-    - Continuous Integration:
-      - General: services/continuous-integration.md
-      - Gitlab-CI: services/gitlab-ci.md
-  - Running Jobs with PBS at the ALCF:
-      - Job Scheduling and Execution: running-jobs/job-and-queue-scheduling.md
-      - Example Job Scripts: running-jobs/example-job-scripts.md
-      - Machine Reservations: running-jobs/machine-reservations.md
-      - Cobalt to PBS option Comparison: running-jobs/pbs-qsub-options-table.md
-  - Aurora:
-      - Getting Started: aurora/getting-started-on-aurora.md
-      - Aurora Programming Environment: aurora/aurora-pe.md
-      - Sunspot to Aurora: aurora/sunspot-to-aurora.md
-      - Early User Notes and Known Issues: aurora/known-issues.md
-      - Hardware Overview: aurora/hardware-overview/machine-overview.md
-      - Node Performance Overview: aurora/node-performance-overview/node-performance-overview.md
-      - Compiling and Linking:
-        - Compiling and Linking Overview: aurora/compiling-and-linking/compiling-and-linking-overview.md
-        - Programming Models: aurora/compiling-and-linking/aurora-programming-models.md
-        - Example Program and Makefile: aurora/compiling-and-linking/aurora-example-program-makefile.md
-      # - LLVM Compilers: aurora/compiling-and-linking/llvm-compilers-aurora.md
-      # - GNU Compilers: aurora/compiling-and-linking/gnu-compilers-aurora.md
-      # - CCE Compilers: aurora/compiling-and-linking/cce-compilers-aurora.md
-      # - Continuous Integration: aurora/compiling-and-linking/continuous-integration-aurora.md
-      - Build Tools:
-        - CMake: aurora/build-tools/cmake-aurora.md
-      - Running Jobs: aurora/running-jobs-aurora.md
-      - Data Management:
-        - Copper: aurora/data-management/copper/copper.md
-        - DAOS: aurora/data-management/daos/daos-overview.md
-        - Lustre (Flare): aurora/data-management/lustre/flare.md
-        - Moving data to Aurora:
-          - DAOS Data Mover: aurora/data-management/moving_data_to_aurora/daos_datamover.md
-          - Globus: aurora/data-management/moving_data_to_aurora/globus.md
-          - SCP: aurora/data-management/moving_data_to_aurora/scp.md
-      - Applications and Libraries:
-        - Libraries:
-          - Cabana: aurora/applications-and-libraries/libraries/cabana-aurora.md
-          #- Math Libraries: aurora/applications-and-libraries/libraries/math-libraries.md
-          #- MKL: aurora/applications-and-libraries/libraries/mkl.md
-          #- MPI: aurora/applications-and-libraries/libraries/mpi.md
-          #- oneDAL: aurora/applications-and-libraries/libraries/onedal.md
-          - Spack PE: aurora/applications-and-libraries/libraries/spack-pe.md
-      - Data Science:
-        #- Julia: aurora/data-science/julia.md
-        - Python: aurora/data-science/python.md
-        #- Applications:
-          #- gpt-neox: aurora/data-science/applications/gpt-neox.md
-        - Containers: aurora/data-science/containers/containers.md
-        - Frameworks:
-          - DeepSpeed: aurora/data-science/frameworks/deepspeed.md
-          - LibTorch: aurora/data-science/frameworks/libtorch.md
-          - Megatron-DeepSpeed: aurora/data-science/frameworks/megatron-deepspeed.md
-          #- JAX: aurora/data-science/frameworks/jax.md
-          - oneCCL: aurora/data-science/frameworks/oneCCL.md
-          - OpenVINO: aurora/data-science/frameworks/openvino.md
-          - PyTorch: aurora/data-science/frameworks/pytorch.md
-          - PyTorch Geometric (PyG): aurora/data-science/frameworks/pyg.md
-          - TensorFlow: aurora/data-science/frameworks/tensorflow.md
-      - Programming Models:
-        - Kokkos: aurora/programming-models/kokkos-aurora.md
-        - Level Zero: aurora/programming-models/level-0.md
-        - OpenCL: aurora/programming-models/opencl-aurora.md
-        - OpenMP: aurora/programming-models/openmp-aurora.md
-        #- RAJA: aurora/programming-models/raja-aurora.md
-        - SYCL: aurora/programming-models/sycl-aurora.md
-      - Debugging Tools:
-        - Overview: aurora/debugging/debugging-overview.md
-        #- gdb-oneapi: aurora/debugging/gdb-oneapi-aurora.md
-      - Performance Tools:
-      #  - Overview: aurora/performance-tools/performance-overview.md
-        - Advisor: aurora/performance-tools/advisor.md
-        - VTune: aurora/performance-tools/vtune.md
-      # - Visualization:
-      #   - ParaView: aurora/visualization/paraview.md
-      - Services:
-        - GitLab: aurora/services/gitlab-ci.md
-        #- JupyterHub: aurora/services/jupyterhub.md
-      - Workflows:
-        # - Balsam: aurora/workflows/balsam.md
-        # - DeepHyper: aurora/workflows/deephyper.md
-        # - libEnsemble: aurora/workflows/libensemble.md
-        # - Parsl: aurora/workflows/parsl.md
-        - SmartSim: aurora/workflows/smartsim.md
-  - Polaris:
-    - Getting Started: polaris/getting-started.md
-    - System Updates: polaris/system-updates.md
-    - Contacting Support and Software Requests: polaris/contacting-support.md
-    - Known Issues: polaris/known-issues.md
-    - Hardware Overview:
-      - Polaris Machine Overview: polaris/hardware-overview/machine-overview.md
-    - Compiling and Linking:
-      - Compiling and Linking Overview: polaris/compiling-and-linking/compiling-and-linking-overview.md
-      - Programming Models: polaris/compiling-and-linking/polaris-programming-models.md
-      - Example Program and Makefile: polaris/compiling-and-linking/polaris-example-program-makefile.md
-      - CCE Compilers: polaris/compiling-and-linking/cce-compilers-polaris.md
-      - GNU Compilers: polaris/compiling-and-linking/gnu-compilers-polaris.md
-      - NVIDIA Compilers: polaris/compiling-and-linking/nvidia-compiler-polaris.md
-      - LLVM Compilers: polaris/compiling-and-linking/llvm-compilers-polaris.md
-      - oneAPI Toolkit: polaris/compiling-and-linking/oneapi-compiler.md
-    - Build Tools:
-        - CMake: polaris/build-tools/cmake-polaris.md
-    - Running Jobs: polaris/running-jobs.md
-    - Applications and Libraries:
-        - Applications:
-            - Amber: polaris/applications-and-libraries/applications/amber.md
-            - GROMACS: polaris/applications-and-libraries/applications/gromacs.md
-            - LAMMPS: polaris/applications-and-libraries/applications/lammps.md
-            - NAMD: polaris/applications-and-libraries/applications/namd.md
-            - NekRS: polaris/applications-and-libraries/applications/nekrs.md
-            - OpenMM: polaris/applications-and-libraries/applications/openmm.md
-            - QMCPACK: polaris/applications-and-libraries/applications/QMCPACK.md
-            - Quantum ESPRESSO: polaris/applications-and-libraries/applications/QuantumESPRESSO.md
-            - VASP: polaris/applications-and-libraries/applications/vasp.md
-        - Libraries:
-            - Math Libraries: polaris/applications-and-libraries/libraries/math-libraries.md
-            - Cabana: polaris/applications-and-libraries/libraries/cabana-polaris.md
-            - Spack PE: polaris/applications-and-libraries/libraries/spack-pe.md
-            - NCCL: polaris/applications-and-libraries/libraries/nccl.md
-            - XALT: polaris/applications-and-libraries/libraries/xalt.md
-    - Containers: polaris/containers/containers.md
-    - Data Science:
-        - Julia: polaris/data-science/julia.md
-        - Python: polaris/data-science/python.md
-        - Frameworks:
-            - TensorFlow: polaris/data-science/frameworks/tensorflow.md
-            - PyTorch: polaris/data-science/frameworks/pytorch.md
-            - JAX: polaris/data-science/frameworks/jax.md
-            - DeepSpeed: polaris/data-science/frameworks/deepspeed.md
-            - LibTorch: polaris/data-science/frameworks/libtorch.md
-        - Applications:
-            - Megatron-DeepSpeed: polaris/data-science/applications/megatron-deepspeed.md
-            - gpt-neox: polaris/data-science/applications/gpt-neox.md
-    - Programming Models:
-        - OpenMP: polaris/programming-models/openmp-polaris.md
-        - SYCL: polaris/programming-models/sycl-polaris.md
-        - Kokkos: polaris/programming-models/kokkos-polaris.md
-    - Debugging Tools:
-        - CUDA-GDB: polaris/debugging-tools/CUDA-GDB.md
-    - Performance Tools:
-        - NVIDIA-Nsight: polaris/performance-tools/NVIDIA-Nsight.md
-    - Visualization:
-        - Visualization on Polaris: polaris/visualization/visualization.md
-        - ParaView (Launch from Client): polaris/visualization/paraview.md
-        - ParaView (Manual Launch): polaris/visualization/paraview-manual-launch.md
-        - VisIt: polaris/visualization/visit.md
-        - FFmpeg: polaris/visualization/ffmpeg.md
-        - ImageMagick: polaris/visualization/imagemagick.md
-        - ParaView Tutorial: polaris/visualization/paraview-tutorial.md
-        - VNC: polaris/visualization/vnc.md
-    - Workflows:
-        - Multi-Instance GPU (MIG) mode: polaris/workflows/mig-compute.md
-        - Balsam: polaris/workflows/balsam.md
-        - Parsl: polaris/workflows/parsl.md
-        - libEnsemble: polaris/workflows/libensemble.md
-        - SmartSim: polaris/workflows/smartsim.md
-  - Sophia:
-    - Machine Overview: sophia/hardware-overview/machine-overview.md
-    - Getting Started: sophia/getting-started.md
-    - Running Jobs: sophia/queueing-and-running-jobs/running-jobs.md
-    - Compiling and Linking: sophia/compiling-and-linking/compiling-and-linking-overview.md
-    - Containers: sophia/containers/containers.md
-    - Data Science:
-        - Python: sophia/data-science/python.md
-        - Fine-tuning with Autotrain: sophia/data-science/fine-tune-LLM-with-Autotrain.md
-    - Visualization:
-        - Visualization on Sophia: sophia/visualization/visualization.md
-        - ParaView (Launch from Client): sophia/visualization/paraview.md
-  - Crux:
-    - Machine Overview: crux/hardware-overview/machine-overview.md
-    - Getting Started: crux/getting-started.md
-    - Running Jobs: crux/queueing-and-running-jobs/running-jobs.md
-    - Compiling and Linking: crux/compiling-and-linking/compiling-and-linking-overview.md
-    - Containers: crux/containers/containers.md
-    - Data Science:
-      - Python: crux/data-science/python.md
-    #- Visualization:
-      #- Visualization on Crux: crux/visualization/visualization.md
-      #- ParaView (Launch from Client): crux/visualization/paraview.md
-  - AI Testbed:
-    - Getting Started: ai-testbed/getting-started.md
-    - Cerebras:
-      - System Overview: ai-testbed/cerebras/system-overview.md
-      - Getting Started: ai-testbed/cerebras/getting-started.md
-      - Running a Model/Program: ai-testbed/cerebras/running-a-model-or-program.md
-      - Customizing Environments: ai-testbed/cerebras/customizing-environment.md
-      - Job Queuing and Submission: ai-testbed/cerebras/job-queuing-and-submission.md
-      - Example Programs: ai-testbed/cerebras/example-programs.md
-      #- Performance Tools: ai-testbed/cerebras/performance-tools.md
-      - Tunneling and Forwarding Ports: ai-testbed/cerebras/tunneling-and-forwarding-ports.md
-      - Miscellaneous: ai-testbed/cerebras/miscellaneous.md
-    - Graphcore:
-      - System Overview: ai-testbed/graphcore/system-overview.md
-      - Getting Started: ai-testbed/graphcore/getting-started.md
-      - Virtual Environment: ai-testbed/graphcore/virtual-environments.md
-      - Running a Model/Program: ai-testbed/graphcore/running-a-model-or-program.md
-      - Job Queuing and Submission: ai-testbed/graphcore/job-queuing-and-submission.md
-      - Example Programs: ai-testbed/graphcore/example-programs.md
-      - Miscellaneous: ai-testbed/graphcore/miscellaneous.md
-      - Documentation: ai-testbed/graphcore/documentation.md
-    - Groq:
-      - System Overview: ai-testbed/groq/system-overview.md
-      - Getting Started: ai-testbed/groq/getting-started.md
-      - Running a Model/Program: ai-testbed/groq/running-a-model-or-program.md
-      #- Example Programs: ai-testbed/groq/example-programs.md
-      - Virtual Environments: ai-testbed/groq/virtual-environments.md
-      - Job Queueing and Submission: ai-testbed/groq/job-queuing-and-submission.md
-      - Profiling with GroqView: ai-testbed/groq/groqview.md
-    - SambaNova:
-      - System Overview: ai-testbed/sambanova/system-overview.md
-      - Getting Started: ai-testbed/sambanova/getting-started.md
-      - Virtual Environment: ai-testbed/sambanova/virtual-environment.md
-      - Running a Model/Program: ai-testbed/sambanova/running-a-model-or-program.md
-      - Job Queuing and Submission: ai-testbed/sambanova/job-queuing-and-submission.md
-      - Example Programs: ai-testbed/sambanova/example-programs.md
-      - Example Multi-Node Programs: ai-testbed/sambanova/example-multi-node-programs.md
-      # - Running BERT Large on Sambanova DataScale SN30-8: ai-testbed/sambanova/running-bert-large-on-sn30.md
-      - Modelzoo Samples: ai-testbed/sambanova/example-modelzoo-programs.md
-      - Tunneling and Forwarding Ports: ai-testbed/sambanova/tunneling-and-forwarding-ports.md
-      - SambaTune for profiling and performance tuning: ai-testbed/sambanova/sambatune.md
-      - Miscellaneous: ai-testbed/sambanova/miscellaneous.md
-      - SambaNova Documentation: ai-testbed/sambanova/documentation.md
-      # - Performance Tools: ai-testbed/sambanova/performance-tools.md
-    - Data Management: ai-testbed/data-management/data-management-overview.md
-  - Facility Policies:
-    - Overview of Policies: policies/facility-policies.md
-    - ALCF Acknowledgement Policy: policies/alcf-acknowledgement-policy.md
-    - Account Policies:
-      - Accounts Policy: policies/accounts/accounts-policy.md
-      - Account Sponsorship & Retention Policy: policies/accounts/account-sponsorship-retention-policy.md
-      - User Authentication Policy: policies/accounts/user-authentication-policy.md
-    - Queue and Scheduling Policies:
-      - Queue and Scheduling Policy: policies/queue-scheduling/queue-and-scheduling-policy.md
-      - Refund Policy: policies/queue-scheduling/refund-policy.md
-      - Pullback Policy: policies/queue-scheduling/pullback-policy.md
-    - Data and Software Policies:
-      - Data Policy: policies/data-and-software-policies/data-policy.md
-      - Software Policy: policies/data-and-software-policies/software-policy.md
-  - Docs Questions/Issues: issues.md
-not_in_nav: |
-  not_in_nav/
-  unused/
-  todo.md
-  TODO.md
-  notes.md
-  account-project-management/index.md
-  # TODO: complete or remove Aurora placeholder pages
-  llvm-compilers-aurora.md
-  gnu-compilers-aurora.md
-  cce-compilers-aurora.md
-  continuous-integration-aurora.md
-  aurora/applications-and-libraries/libraries/math-libraries.md
-  aurora/applications-and-libraries/libraries/mkl.md
-  aurora/applications-and-libraries/libraries/mpi.md
-  aurora/applications-and-libraries/libraries/onedal.md
-  aurora/data-science/julia.md
-  aurora/data-science/applications/gpt-neox.md
-  aurora/data-science/frameworks/deepspeed.md
-  aurora/data-science/frameworks/jax.md
-  aurora/programming-models/raja-aurora.md
-  aurora/debugging/gdb-oneapi-aurora.md
-  aurora/performance-tools/performance-overview.md
-  aurora/visualization/paraview.md
-  aurora/services/jupyterhub.md
-  aurora/workflows/balsam.md
-  aurora/workflows/deephyper.md
-  aurora/workflows/libensemble.md
-  aurora/workflows/parsl.md
-
+repo_name: 'argonne-lcf/user-guides'
+repo_url: 'https://github.com/argonne-lcf/user-guides'
+site_url: 'https://docs.alcf.anl.gov/'
 theme:
   name: 'material'
   custom_dir: overrides
@@ -311,8 +16,12 @@ theme:
     - search.highlight
     - search.suggest
     - content.code.copy
+    - content.action.edit
+    - content.action.view
+    - toc.follow
   logo: 'images/Argonne_wireframe_white_transparent.png'
   favicon: 'images/alcf_favicon.ico'
+
 extra_css:
   - stylesheets/alcf-extra.css
 
@@ -357,10 +66,6 @@ validation:
   anchors: warn
   not_found: warn
 
-repo_name: 'argonne-lcf/user-guides'
-repo_url: 'https://github.com/argonne-lcf/user-guides'
-site_url: 'https://docs.alcf.anl.gov/'
-
 extra:
   social:
     - icon: 'fontawesome/brands/github-alt'
@@ -375,3 +80,314 @@ plugins:
       title_mode: pymdownx.tabbed
   - search:
       lang: en
+nav:
+  - ALCF User Guides: index.md
+
+  - Account and Project Management:
+    - Accounts and Access: account-project-management/accounts-and-access/user-account-overview.md
+    - Passcode Tokens: account-project-management/accounts-and-access/alcf-passcode-tokens.md
+    - Accounts and Access FAQs: account-project-management/accounts-and-access/accounts-and-access-faqs.md
+    - Project Management:
+      - Starting Your ALCF Award: account-project-management/project-management/starting-alcf-award.md
+      - Managing Your Team Members: account-project-management/project-management/team-management.md
+      - Reporting: account-project-management/project-management/project-reports.md
+    - Allocations:
+      - Allocations on ALCF Computing Resources: account-project-management/allocation-management/overview.md
+      - Managing Your Allocations: account-project-management/allocation-management/allocation-management.md
+      - sbank Allocation Accounting System: account-project-management/allocation-management/sbank-allocation-accounting-system.md
+
+  - Data Management:
+    - ALCF Community Data Co-Op: data-management/acdc/acdc-overview.md
+    - Sharing on Eagle Using Globus: data-management/acdc/eagle-data-sharing.md
+    - Transferring Data to Eagle: data-management/acdc/transferring-data-to-eagle.md
+    - Data Transfer:
+      - SFTP and SCP: data-management/data-transfer/sftp-scp.md
+      - Using Globus: data-management/data-transfer/using-globus.md
+    - File System & Storage:
+      - File Systems: data-management/filesystem-and-storage/file-systems.md
+      - Data Storage: data-management/filesystem-and-storage/data-storage.md
+      - HPSS: data-management/filesystem-and-storage/hpss.md
+      - Disk Quota: data-management/filesystem-and-storage/disk-quota.md
+
+  - Facility Policies:
+    - Overview of Policies: policies/facility-policies.md
+    - ALCF Acknowledgement Policy: policies/alcf-acknowledgement-policy.md
+    - Account Policies:
+      - Accounts Policy: policies/accounts/accounts-policy.md
+      - Account Sponsorship & Retention Policy: policies/accounts/account-sponsorship-retention-policy.md
+      - User Authentication Policy: policies/accounts/user-authentication-policy.md
+    - Queue and Scheduling Policies:
+      - Queue and Scheduling Policy: policies/queue-scheduling/queue-and-scheduling-policy.md
+      - Refund Policy: policies/queue-scheduling/refund-policy.md
+      - Pullback Policy: policies/queue-scheduling/pullback-policy.md
+    - Data and Software Policies:
+      - Data Policy: policies/data-and-software-policies/data-policy.md
+      - Software Policy: policies/data-and-software-policies/software-policy.md
+
+  - Machines:
+    - AI Testbed:
+      - Getting Started: ai-testbed/getting-started.md
+      - Cerebras:
+        - System Overview: ai-testbed/cerebras/system-overview.md
+        - Getting Started: ai-testbed/cerebras/getting-started.md
+        - Running a Model/Program: ai-testbed/cerebras/running-a-model-or-program.md
+        - Customizing Environments: ai-testbed/cerebras/customizing-environment.md
+        - Job Queuing and Submission: ai-testbed/cerebras/job-queuing-and-submission.md
+        - Example Programs: ai-testbed/cerebras/example-programs.md
+        #- Performance Tools: ai-testbed/cerebras/performance-tools.md
+        - Tunneling and Forwarding Ports: ai-testbed/cerebras/tunneling-and-forwarding-ports.md
+        - Miscellaneous: ai-testbed/cerebras/miscellaneous.md
+      - Graphcore:
+        - System Overview: ai-testbed/graphcore/system-overview.md
+        - Getting Started: ai-testbed/graphcore/getting-started.md
+        - Virtual Environment: ai-testbed/graphcore/virtual-environments.md
+        - Running a Model/Program: ai-testbed/graphcore/running-a-model-or-program.md
+        - Job Queuing and Submission: ai-testbed/graphcore/job-queuing-and-submission.md
+        - Example Programs: ai-testbed/graphcore/example-programs.md
+        - Miscellaneous: ai-testbed/graphcore/miscellaneous.md
+        - Documentation: ai-testbed/graphcore/documentation.md
+      - Groq:
+        - System Overview: ai-testbed/groq/system-overview.md
+        - Getting Started: ai-testbed/groq/getting-started.md
+        - Running a Model/Program: ai-testbed/groq/running-a-model-or-program.md
+        #- Example Programs: ai-testbed/groq/example-programs.md
+        - Virtual Environments: ai-testbed/groq/virtual-environments.md
+        - Job Queueing and Submission: ai-testbed/groq/job-queuing-and-submission.md
+        - Profiling with GroqView: ai-testbed/groq/groqview.md
+      - SambaNova:
+        - System Overview: ai-testbed/sambanova/system-overview.md
+        - Getting Started: ai-testbed/sambanova/getting-started.md
+        - Virtual Environment: ai-testbed/sambanova/virtual-environment.md
+        - Running a Model/Program: ai-testbed/sambanova/running-a-model-or-program.md
+        - Job Queuing and Submission: ai-testbed/sambanova/job-queuing-and-submission.md
+        - Example Programs: ai-testbed/sambanova/example-programs.md
+        - Example Multi-Node Programs: ai-testbed/sambanova/example-multi-node-programs.md
+        # - Running BERT Large on Sambanova DataScale SN30-8: ai-testbed/sambanova/running-bert-large-on-sn30.md
+        - Modelzoo Samples: ai-testbed/sambanova/example-modelzoo-programs.md
+        - Tunneling and Forwarding Ports: ai-testbed/sambanova/tunneling-and-forwarding-ports.md
+        - SambaTune for profiling and performance tuning: ai-testbed/sambanova/sambatune.md
+        - Miscellaneous: ai-testbed/sambanova/miscellaneous.md
+        - SambaNova Documentation: ai-testbed/sambanova/documentation.md
+        # - Performance Tools: ai-testbed/sambanova/performance-tools.md
+      - Data Management: ai-testbed/data-management/data-management-overview.md
+
+
+    - Aurora:
+        - Getting Started: aurora/getting-started-on-aurora.md
+        - Aurora Programming Environment: aurora/aurora-pe.md
+        - Sunspot to Aurora: aurora/sunspot-to-aurora.md
+        - Early User Notes and Known Issues: aurora/known-issues.md
+        - Hardware Overview: aurora/hardware-overview/machine-overview.md
+        - Node Performance Overview: aurora/node-performance-overview/node-performance-overview.md
+        - Compiling and Linking:
+          - Compiling and Linking Overview: aurora/compiling-and-linking/compiling-and-linking-overview.md
+          - Programming Models: aurora/compiling-and-linking/aurora-programming-models.md
+          - Example Program and Makefile: aurora/compiling-and-linking/aurora-example-program-makefile.md
+        # - LLVM Compilers: aurora/compiling-and-linking/llvm-compilers-aurora.md
+        # - GNU Compilers: aurora/compiling-and-linking/gnu-compilers-aurora.md
+        # - CCE Compilers: aurora/compiling-and-linking/cce-compilers-aurora.md
+        # - Continuous Integration: aurora/compiling-and-linking/continuous-integration-aurora.md
+        - Build Tools:
+          - CMake: aurora/build-tools/cmake-aurora.md
+        - Running Jobs: aurora/running-jobs-aurora.md
+        - Data Management:
+          - Copper: aurora/data-management/copper/copper.md
+          - DAOS: aurora/data-management/daos/daos-overview.md
+          - Lustre (Flare): aurora/data-management/lustre/flare.md
+          - Moving data to Aurora:
+            - DAOS Data Mover: aurora/data-management/moving_data_to_aurora/daos_datamover.md
+            - Globus: aurora/data-management/moving_data_to_aurora/globus.md
+            - SCP: aurora/data-management/moving_data_to_aurora/scp.md
+        - Applications and Libraries:
+          - Libraries:
+            - Cabana: aurora/applications-and-libraries/libraries/cabana-aurora.md
+            #- Math Libraries: aurora/applications-and-libraries/libraries/math-libraries.md
+            #- MKL: aurora/applications-and-libraries/libraries/mkl.md
+            #- MPI: aurora/applications-and-libraries/libraries/mpi.md
+            #- oneDAL: aurora/applications-and-libraries/libraries/onedal.md
+            - Spack PE: aurora/applications-and-libraries/libraries/spack-pe.md
+        - Data Science:
+          #- Julia: aurora/data-science/julia.md
+          - Python: aurora/data-science/python.md
+          #- Applications:
+            #- gpt-neox: aurora/data-science/applications/gpt-neox.md
+          - Containers: aurora/data-science/containers/containers.md
+          - Frameworks:
+            - DeepSpeed: aurora/data-science/frameworks/deepspeed.md
+            - LibTorch: aurora/data-science/frameworks/libtorch.md
+            - Megatron-DeepSpeed: aurora/data-science/frameworks/megatron-deepspeed.md
+            #- JAX: aurora/data-science/frameworks/jax.md
+            - oneCCL: aurora/data-science/frameworks/oneCCL.md
+            - OpenVINO: aurora/data-science/frameworks/openvino.md
+            - PyTorch: aurora/data-science/frameworks/pytorch.md
+            - PyTorch Geometric (PyG): aurora/data-science/frameworks/pyg.md
+            - TensorFlow: aurora/data-science/frameworks/tensorflow.md
+        - Programming Models:
+          - Kokkos: aurora/programming-models/kokkos-aurora.md
+          - Level Zero: aurora/programming-models/level-0.md
+          - OpenCL: aurora/programming-models/opencl-aurora.md
+          - OpenMP: aurora/programming-models/openmp-aurora.md
+          #- RAJA: aurora/programming-models/raja-aurora.md
+          - SYCL: aurora/programming-models/sycl-aurora.md
+        - Debugging Tools:
+          - Overview: aurora/debugging/debugging-overview.md
+          #- gdb-oneapi: aurora/debugging/gdb-oneapi-aurora.md
+        - Performance Tools:
+        #  - Overview: aurora/performance-tools/performance-overview.md
+          - Advisor: aurora/performance-tools/advisor.md
+          - VTune: aurora/performance-tools/vtune.md
+        # - Visualization:
+        #   - ParaView: aurora/visualization/paraview.md
+        - Services:
+          - GitLab: aurora/services/gitlab-ci.md
+          #- JupyterHub: aurora/services/jupyterhub.md
+        - Workflows:
+          # - Balsam: aurora/workflows/balsam.md
+          # - DeepHyper: aurora/workflows/deephyper.md
+          # - libEnsemble: aurora/workflows/libensemble.md
+          # - Parsl: aurora/workflows/parsl.md
+          - SmartSim: aurora/workflows/smartsim.md
+
+    - Crux:
+      - Machine Overview: crux/hardware-overview/machine-overview.md
+      - Getting Started: crux/getting-started.md
+      - Running Jobs: crux/queueing-and-running-jobs/running-jobs.md
+      - Compiling and Linking: crux/compiling-and-linking/compiling-and-linking-overview.md
+      - Containers: crux/containers/containers.md
+      - Data Science:
+        - Python: crux/data-science/python.md
+      #- Visualization:
+        #- Visualization on Crux: crux/visualization/visualization.md
+        #- ParaView (Launch from Client): crux/visualization/paraview.md
+
+    - Polaris:
+      - Getting Started: polaris/getting-started.md
+      - System Updates: polaris/system-updates.md
+      - Contacting Support and Software Requests: polaris/contacting-support.md
+      - Known Issues: polaris/known-issues.md
+      - Hardware Overview:
+        - Polaris Machine Overview: polaris/hardware-overview/machine-overview.md
+      - Compiling and Linking:
+        - Compiling and Linking Overview: polaris/compiling-and-linking/compiling-and-linking-overview.md
+        - Programming Models: polaris/compiling-and-linking/polaris-programming-models.md
+        - Example Program and Makefile: polaris/compiling-and-linking/polaris-example-program-makefile.md
+        - CCE Compilers: polaris/compiling-and-linking/cce-compilers-polaris.md
+        - GNU Compilers: polaris/compiling-and-linking/gnu-compilers-polaris.md
+        - NVIDIA Compilers: polaris/compiling-and-linking/nvidia-compiler-polaris.md
+        - LLVM Compilers: polaris/compiling-and-linking/llvm-compilers-polaris.md
+        - oneAPI Toolkit: polaris/compiling-and-linking/oneapi-compiler.md
+      - Build Tools:
+          - CMake: polaris/build-tools/cmake-polaris.md
+      - Running Jobs: polaris/running-jobs.md
+      - Applications and Libraries:
+          - Applications:
+              - Amber: polaris/applications-and-libraries/applications/amber.md
+              - GROMACS: polaris/applications-and-libraries/applications/gromacs.md
+              - LAMMPS: polaris/applications-and-libraries/applications/lammps.md
+              - NAMD: polaris/applications-and-libraries/applications/namd.md
+              - NekRS: polaris/applications-and-libraries/applications/nekrs.md
+              - OpenMM: polaris/applications-and-libraries/applications/openmm.md
+              - QMCPACK: polaris/applications-and-libraries/applications/QMCPACK.md
+              - Quantum ESPRESSO: polaris/applications-and-libraries/applications/QuantumESPRESSO.md
+              - VASP: polaris/applications-and-libraries/applications/vasp.md
+          - Libraries:
+              - Math Libraries: polaris/applications-and-libraries/libraries/math-libraries.md
+              - Cabana: polaris/applications-and-libraries/libraries/cabana-polaris.md
+              - Spack PE: polaris/applications-and-libraries/libraries/spack-pe.md
+              - NCCL: polaris/applications-and-libraries/libraries/nccl.md
+              - XALT: polaris/applications-and-libraries/libraries/xalt.md
+      - Containers: polaris/containers/containers.md
+      - Data Science:
+          - Julia: polaris/data-science/julia.md
+          - Python: polaris/data-science/python.md
+          - Frameworks:
+              - TensorFlow: polaris/data-science/frameworks/tensorflow.md
+              - PyTorch: polaris/data-science/frameworks/pytorch.md
+              - JAX: polaris/data-science/frameworks/jax.md
+              - DeepSpeed: polaris/data-science/frameworks/deepspeed.md
+              - LibTorch: polaris/data-science/frameworks/libtorch.md
+          - Applications:
+              - Megatron-DeepSpeed: polaris/data-science/applications/megatron-deepspeed.md
+              - gpt-neox: polaris/data-science/applications/gpt-neox.md
+      - Programming Models:
+          - OpenMP: polaris/programming-models/openmp-polaris.md
+          - SYCL: polaris/programming-models/sycl-polaris.md
+          - Kokkos: polaris/programming-models/kokkos-polaris.md
+      - Debugging Tools:
+          - CUDA-GDB: polaris/debugging-tools/CUDA-GDB.md
+      - Performance Tools:
+          - NVIDIA-Nsight: polaris/performance-tools/NVIDIA-Nsight.md
+      - Visualization:
+          - Visualization on Polaris: polaris/visualization/visualization.md
+          - ParaView (Launch from Client): polaris/visualization/paraview.md
+          - ParaView (Manual Launch): polaris/visualization/paraview-manual-launch.md
+          - VisIt: polaris/visualization/visit.md
+          - FFmpeg: polaris/visualization/ffmpeg.md
+          - ImageMagick: polaris/visualization/imagemagick.md
+          - ParaView Tutorial: polaris/visualization/paraview-tutorial.md
+          - VNC: polaris/visualization/vnc.md
+      - Workflows:
+          - Multi-Instance GPU (MIG) mode: polaris/workflows/mig-compute.md
+          - Balsam: polaris/workflows/balsam.md
+          - Parsl: polaris/workflows/parsl.md
+          - libEnsemble: polaris/workflows/libensemble.md
+          - SmartSim: polaris/workflows/smartsim.md
+
+    - Sophia:
+      - Machine Overview: sophia/hardware-overview/machine-overview.md
+      - Getting Started: sophia/getting-started.md
+      - Running Jobs: sophia/queueing-and-running-jobs/running-jobs.md
+      - Compiling and Linking: sophia/compiling-and-linking/compiling-and-linking-overview.md
+      - Containers: sophia/containers/containers.md
+      - Data Science:
+          - Python: sophia/data-science/python.md
+          - Fine-tuning with Autotrain: sophia/data-science/fine-tune-LLM-with-Autotrain.md
+      - Visualization:
+          - Visualization on Sophia: sophia/visualization/visualization.md
+          - ParaView (Launch from Client): sophia/visualization/paraview.md
+
+  - Running Jobs with PBS at the ALCF:
+      - Job Scheduling and Execution: running-jobs/job-and-queue-scheduling.md
+      - Example Job Scripts: running-jobs/example-job-scripts.md
+      - Machine Reservations: running-jobs/machine-reservations.md
+      - Cobalt to PBS option Comparison: running-jobs/pbs-qsub-options-table.md
+
+  - Services: # services/index.md  # Cant directly link to this in the nav sidebar, since
+    # it is a dropdown. Only linked to in base docs/index.md
+    - Getting Started: services/getting-started.md
+    - JupyterHub: services/jupyter-hub.md
+    - Continuous Integration:
+      - General: services/continuous-integration.md
+      - Gitlab-CI: services/gitlab-ci.md
+
+  - Questions/Issues: issues.md
+
+not_in_nav: |
+  not_in_nav/
+  unused/
+  todo.md
+  TODO.md
+  notes.md
+  account-project-management/index.md
+  # TODO: complete or remove Aurora placeholder pages
+  llvm-compilers-aurora.md
+  gnu-compilers-aurora.md
+  cce-compilers-aurora.md
+  continuous-integration-aurora.md
+  aurora/applications-and-libraries/libraries/math-libraries.md
+  aurora/applications-and-libraries/libraries/mkl.md
+  aurora/applications-and-libraries/libraries/mpi.md
+  aurora/applications-and-libraries/libraries/onedal.md
+  aurora/data-science/julia.md
+  aurora/data-science/applications/gpt-neox.md
+  aurora/data-science/frameworks/deepspeed.md
+  aurora/data-science/frameworks/jax.md
+  aurora/programming-models/raja-aurora.md
+  aurora/debugging/gdb-oneapi-aurora.md
+  aurora/performance-tools/performance-overview.md
+  aurora/visualization/paraview.md
+  aurora/services/jupyterhub.md
+  aurora/workflows/balsam.md
+  aurora/workflows/deephyper.md
+  aurora/workflows/libensemble.md
+  aurora/workflows/parsl.md


### PR DESCRIPTION
Changes:

- Alphabetize sidebar
- Remove `ALCF User Guides` title from left sidebar
	- Replace: `ALCF User Guides` <-- ~~`Home`~~
- Move {AI Testbed, Aurora, Crux, Polaris, Sophia} into `Machines/` section in the sidebar.
 
  Compare old (left) vs. new (right):

  <img width="40%" src="https://github.com/user-attachments/assets/667d6f4a-fdb3-48cb-9934-9e4e220936ce">
  <img width="40%" src="https://github.com/user-attachments/assets/4faccf43-e5fe-4964-8c79-e0bc695fbd1a">