### PR TITLE
Some comments on the Aurora Parsl Docs

### DIFF
--- a/docs/aurora/workflows/parsl.md
+++ b/docs/aurora/workflows/parsl.md
@@ -165,7 +165,7 @@ with parsl.load(aurora_single_tile_config):
 
 Note that a Parsl workflow script must block at some point on the result of all tasks that are created in order to ensure that the tasks complete.
 
-To run this workflow script:
+To run this workflow script, execute the following from a login node:
 ```bash linenums="1"
 source $HOME/_env/bin/activate
 python my_parsl_workflow.py
@@ -208,11 +208,11 @@ mpi_ensemble_config = Config(
             # This creates 1 worker for each multinode task slot
             max_workers_per_block=nodes_per_job//nodes_per_task, 
             provider=PBSProProvider(
-                account="Aurora_deployment",
+                account="Aurora_deployment", # (1)!
                 worker_init=f"""source $HOME/_env/bin/activate; \
-                                cd {working_directory}""",
+                                cd {working_directory}""", # (2)!
                 walltime="0:30:00",
-                queue="lustre_scaling",
+                queue="lustre_scaling", # (3)!
                 scheduler_options="#PBS -l filesystems=home:flare",
                 launcher=SimpleLauncher(),
                 select_options="",
@@ -225,6 +225,10 @@ mpi_ensemble_config = Config(
     retries=1,
 )
 ```
+
+1. Users should change this with their project name
+2. Users should update this with the path to their venv and all needed modules
+3. Users should change this with the appropriate queue name
 
 This example workflow uses this `Config` to run an ensemble of 2-node MPI tasks:
 
@@ -272,6 +276,17 @@ with parsl.load(mpi_ensemble_config):
         tf.result()
         
     print("Tasks done!")
+```
+
+!!! info "Updating the `Config` object in `config.py` and the MPI executable"
+	Users should make sure to update the account and queue names to match their allocation and job needs. 
+	Additionally, please ensure to update the `worker_init` entry in the `config.py` file with all modules needed to run the workflow script and applications.
+	Finally, please update the MPI executable and `mpiexec` arguments in the `mpi_hello_affinity()` function of `my_parsl_workflow.py` as needed.
+
+The workflow can be launched from a login node by executing
+```bash
+source $HOME/_env/bin/activate
+python my_parsl_workflow.py
 ```
 
 ## Run Parsl Workflow within a single PBS Job

--- a/docs/aurora/workflows/parsl.md
+++ b/docs/aurora/workflows/parsl.md
@@ -22,6 +22,9 @@ source $HOME/_env/bin/activate
 pip install parsl
 ```
 
+!!! info "Python on Aurora"
+	To get Python on Aurora, users can either load the AI frameworks module with `module load frameworks` or the basic Python 3.10 module with `module load python/3.10.13`
+
 When using Parsl to distribute work over many PBS Jobs (first two examples below), your workflow script will be executed on a login node and will not return until all tasks are completed.  In this situation, it is advisable to run your script in a [screen](https://linuxize.com/post/how-to-use-linux-screen/) session on the login node.
 
 ## Parsl Config for a Large Ensemble of Single Tile tasks run over many PBS Jobs

--- a/docs/aurora/workflows/parsl.md
+++ b/docs/aurora/workflows/parsl.md
@@ -5,10 +5,13 @@
 Parsl uses Python's concurrent futures module to create functions that return a Python futures object.  A Parsl workflow operates by creating futures for tasks that the Parsl executor will then fulfill by running them on available compute resources.
 
 A Parsl workflow contains two parts:
-* the workflow logic of applications, tasks and task dependencies
-* the configuration of compute resources that execute tasks
 
-Here we sketch out some possible configurations for executing workflows on Aurora.  These docs were written for Parsl 2025.1.13.
+- The workflow logic of applications, tasks and task dependencies
+- The configuration of compute resources that execute tasks
+
+Here we sketch out some possible configurations for executing workflows on Aurora.  
+
+!!! info "These docs were written for Parsl 2025.1.13."
 
 ## Installation and Setup
 Parsl is a Python library and can be installed with `pip`.  For example, in a Python virtual environment:

--- a/docs/aurora/workflows/parsl.md
+++ b/docs/aurora/workflows/parsl.md
@@ -66,12 +66,12 @@ aurora_single_tile_config = Config(
             # Options that specify properties of PBS Jobs
             provider=PBSProProvider(
                 # Project name
-                account="Aurora_deployment",
+                account="Aurora_deployment", # (1)!
                 # Submission queue
-                queue="debug",
+                queue="debug", # (2)!
                 # Commands run before workers launched
                 # Make sure to activate your environment where Parsl is installed
-                worker_init=f'''source $HOME/_env/bin/activate; cd {execute_dir}''',
+                worker_init=f'''source $HOME/_env/bin/activate; cd {execute_dir}''', # (3)!
                 # Wall time for batch jobs
                 walltime="0:30:00",
                 # Change if data/modules located on other filesystem
@@ -98,6 +98,10 @@ aurora_single_tile_config = Config(
 )
 ```
 
+1. Users should change this with their project name
+2. Users should change this with the appropriate queue name
+3. Users should update this with the path to their venv
+
 Import this `Config` object and use in a workflow script, e.g.:
 
 ```python linenums="1" title="my_parsl_workflow.py"
@@ -111,7 +115,7 @@ from config import aurora_single_tile_config
 # Bash apps are for executing compiled applications or other shell commands
 @bash_app
 def hello_affinity(stdout='hello.stdout', stderr='hello.stderr'):
-    return f'$HOME/GettingStarted/Examples/Aurora/affinity_gpu/sycl/hello_affinity'
+    return f'echo "Hello from mpiexec"'
 
 # Python apps are for executing native python functions
 @python_app
@@ -154,6 +158,11 @@ with parsl.load(aurora_single_tile_config):
     
     print("Tasks done!")
 ```
+
+!!! info "Updating the `Config` object in `config.py`"
+	Users should make sure to update the account and queue names to match their allocation and job needs. 
+	Additionally, please ensure to update the `worker_init` entry with all modules needed to run the workflow script and applications.
+
 Note that a Parsl workflow script must block at some point on the result of all tasks that are created in order to ensure that the tasks complete.
 
 To run this workflow script:


### PR DESCRIPTION
I ran through the examples in the documentation and added some reviews that I thought were helpful for me to be able to run things.

@cms21, please note:

- I was running into issues executing the example code as it was because the modules needed to get Python were missing from the config script. So I added some notes to hopefully make this clearer to users.
- I was also running into issues because I did not have the `hello_affinity` executable at the same path or even built. I notice other parts of the docs do this too, which is something I think needs to be fixed overall. So I attempted two solutions: 1) in the first example I changed `def hello_affinity()` to run `echo "Hello from mpiexec"` instead, and 2) in the second example I added an info box to emphasize that the contents of `def mpi_hello_affinity()` should be modified for the example to run. A third option is possibly to add some more information on this page to tell users where to find `hello_affinity` and build it.

 Please let me know if anything is unclear and of course feel free to make any changes, those were just my suggestions.