### PR TITLE
Add instructions for multiple CCS

### DIFF
--- a/docs/aurora/data-science/frameworks/pytorch.md
+++ b/docs/aurora/data-science/frameworks/pytorch.md
@@ -374,3 +374,48 @@ mpiexec -np ${NRANKS} -ppn ${NRANKS_PER_NODE} \
 --cpu-bind ${CPU_BIND} \
 python path/to/application.py
 ```
+
+### Distributed Training with Multiple CCSs
+
+The Intel PVC GPUs contain 4 Compute Command Streamers (CCSs) on each tile, which can be used to group Execution Units (EUs) into common pools. 
+These pools can then be accessed by separate processes thereby enabling distributed training with multiple MPI processes per tile. 
+This feature on PVC is similar to MPS on NVIDIA GPUs 
+and can be beneficial for increasing computational throughput when training or performing inference with smaller models which do not require the entire memory of a PVC tile.
+For more information, see the section on using multiple CCSs under the [Running Jobs on Aurora](../../running-jobs-aurora.md) page.
+
+Distributed training with multiple CCSs can be enabled programmatically within the user code by explicitly setting the `xpu` device in PyTorch, for example
+
+```python linenums="1"
+import os
+from argparse import ArgumentParser
+import torch
+import intel_extension_for_pytorch
+import oneccl_bindings_for_pytorch
+
+parser = ArgumentParser(description='CCS Test')
+parser.add_argument('--ppd', default=1, type=int, help='Number of MPI processes per GPU device')
+args = parser.parse_args()
+
+local_rank = int(os.environ.get('PALS_LOCAL_RANKID'))
+if torch.xpu.is_available():
+    xpu_id = local_rank//args.ppd if torch.xpu.device_count()>1 else 0
+    assert xpu_id>=0 and xpu_id<torch.xpu.device_count(), \
+           f"Assert failed: xpu_id={xpu_id} and {torch.xpu.device_count()} available devices"
+    torch.xpu.set_device(xpu_id)
+```
+
+and then adding the proper environment variables and `mpiexec` settings in the run script. 
+For example, to run distributed training with 48 MPI processes per node exposing 4 CCSs per tile, set
+
+```bash linenums="1"
+export ZEX_NUMBER_OF_CCS=0:4,1:4,2:4,3:4,4:4,5:4,6:4,7:4,8:4,9:4,10:4,11:4
+BIND_LIST="1:2:4:6:8:10:12:14:16:18:20:22:24:26:28:30:32:34:36:38:40:42:44:46:53:54:56:58:60:62:64:66:68:70:72:74:76:78:80:82:84:86:88:90:92:94:96:98"
+mpiexec --pmi=pmix --envall -n 48 --ppn 48 \
+    --cpu-bind=verbose,list:${BIND_LIST} \
+    python training_script.py --ppd=4
+```
+
+!!! warning "Multiple CCSs and oneCCL"
+	When performing distributed training exposing multiple CCSs, the collective communications with the oneCCL backend are delegated to the CPU. 
+	This is done in the background by oneCCL, so no change to the users' code is required to move data between host and device, however it may impact the performance of the collectives at scale.
+

--- a/docs/aurora/data-science/frameworks/pytorch.md
+++ b/docs/aurora/data-science/frameworks/pytorch.md
@@ -383,7 +383,7 @@ This feature on PVC is similar to MPS on NVIDIA GPUs
 and can be beneficial for increasing computational throughput when training or performing inference with smaller models which do not require the entire memory of a PVC tile.
 For more information, see the section on using multiple CCSs under the [Running Jobs on Aurora](../../running-jobs-aurora.md) page.
 
-Distributed training with multiple CCSs can be enabled programmatically within the user code by explicitly setting the `xpu` device in PyTorch, for example
+For both DDP and Horovod, distributed training with multiple CCSs can be enabled programmatically within the user code by explicitly setting the `xpu` device in PyTorch, for example
 
 ```python linenums="1"
 import os
@@ -431,6 +431,17 @@ exec "$@"
 ```
 
 1. Note that the script takes the number of CCSs exposed as a command line argument
+
+!!! info "Checking PVC usage with `xpu-smi`"
+	Users are invited to check correct placement of the MPI ranks on the different tiles by connecting to the compute node being used and executing 
+	```bash
+	module load xpu-smi
+	watch -n 0.1 xpu-smi stats -d <GPU_ID> # (1)!
+    ```
+
+	1. In this case, GPU_ID refers to the 6 GPU on each node, not an individual tile
+
+	and checking the GPU and memory utilization of both tiles.
 
 !!! warning "Multiple CCSs and oneCCL"
 	- When performing distributed training exposing multiple CCSs, the collective communications with the oneCCL backend are delegated to the CPU. This is done in the background by oneCCL, so no change to the users' code is required to move data between host and device, however it may impact the performance of the collectives at scale.

--- a/docs/aurora/data-science/frameworks/pytorch.md
+++ b/docs/aurora/data-science/frameworks/pytorch.md
@@ -393,7 +393,8 @@ import intel_extension_for_pytorch
 import oneccl_bindings_for_pytorch
 
 parser = ArgumentParser(description='CCS Test')
-parser.add_argument('--ppd', default=1, type=int, help='Number of MPI processes per GPU device')
+parser.add_argument('--ppd', default=1, type=int, choices=[1,2,4], # (1)!
+                    help='Number of MPI processes per GPU device')
 args = parser.parse_args()
 
 local_rank = int(os.environ.get('PALS_LOCAL_RANKID'))
@@ -403,6 +404,8 @@ if torch.xpu.is_available():
            f"Assert failed: xpu_id={xpu_id} and {torch.xpu.device_count()} available devices"
     torch.xpu.set_device(xpu_id)
 ```
+
+1. PVC GPU allow the use of 1, 2 or 4 CCSs on each tile
 
 and then adding the proper environment variables and `mpiexec` settings in the run script. 
 For example, to run distributed training with 48 MPI processes per node exposing 4 CCSs per tile, set

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -433,7 +433,7 @@ export ZEX_NUMBER_OF_CCS=0:4,1:4,2:4,3:4,4:4,5:4
 	- `ZE_AFFINITY_MASK` is read by the Level Zero driver prior to `ZEX_NUMBER_OF_CCS`, thus `ZEX_NUMBER_OF_CCS` should refer to the GPU IDs of the masked devices.
 	- Users can expose different number of CCSs on the different GPU and tiles, the desired CCS mode does not need to be uniform across the GPUs on a node. 
 
-More information can be found on [Intel's documentation page](https://github.com/intel/compute-runtime/blob/master/level_zero/doc/experimental_extensions/MULTI_CCS_MODES.md).
+More information can be found on Intel's [documentation](https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-1/multi-tile-advanced-topics.html) and [GitHub](https://github.com/intel/compute-runtime/blob/master/level_zero/doc/experimental_extensions/MULTI_CCS_MODES.md) pages.
 
 
 ## <a name="Running-Multiple-MPI-Applications-on-a-node"></a>Running Multiple MPI Applications on a node

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -431,11 +431,9 @@ export ZEX_NUMBER_OF_CCS=0:4,1:4,2:4,3:4,4:4,5:4
 	- Please be mindful of the device hierarchy selected. When running with `ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE`, 6 PVC are exposed to the applications and the above command should be used, noting that `export ZEX_NUMBER_OF_CCS=0:4` exposes 4 CCSs on both tiles of GPU 0. When running with `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, the 12 PVC tiles are exposed to the applications (tile-as-device), thus `export ZEX_NUMBER_OF_CCS=0:4` only refers to tile 0 of GPU 0. To expose multiple CCSs on all tiles, users should use `export ZEX_NUMBER_OF_CCS=0:4,1:4,2:4,3:4,4:4,5:4,6:4,7:4,8:4,9:4,10:4,11:4`.
 	- Users should also be mindful of the CPU binding affinity guidelines described above, ensuring that MPI processes are bound to the correct socket and GPU pairs.
 	- `ZE_AFFINITY_MASK` is read by the Level Zero driver prior to `ZEX_NUMBER_OF_CCS`, thus `ZEX_NUMBER_OF_CCS` should refer to the GPU IDs of the masked devices.
-	- Users can expose different number of CCSs on the different GPU and tiles, the CCS mode does not need to be uniform across the GPU on a node. 
+	- Users can expose different number of CCSs on the different GPU and tiles, the desired CCS mode does not need to be uniform across the GPUs on a node. 
 
 More information can be found on [Intel's documentation page](https://github.com/intel/compute-runtime/blob/master/level_zero/doc/experimental_extensions/MULTI_CCS_MODES.md).
-
-Intel PVC GPUs feature Compute-Command Streamers (CCSs) that cluster Execution Units (EUs), similar to the MPS capabilities on NVIDIA GPUs. These CCSs allow access to a shared pool of EUs. The hardware enables the selection of a specific distribution of EUs among CCSs, which can be set to 4, 2, or 1 (default) per stack using an environmental variable
 
 
 ## <a name="Running-Multiple-MPI-Applications-on-a-node"></a>Running Multiple MPI Applications on a node

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -362,7 +362,8 @@ Note that the threads MPI rank 6 are bound to cross both socket 0 and socket 1, 
 </figure>
 
 
-**NOTE:** For a script to help provide cpu-bindings, you can use [get_cpu_bind_aurora](https://github.com/argonne-lcf/pbs_utils/blob/main/get_cpu_bind_aurora). Please see [User Guide for Aurora CPU Binding Script](https://github.com/argonne-lcf/pbs_utils/blob/main/doc/guide-get_cpu_bind_aurora.md) for documentation. 
+!!! info
+	For a script to help provide cpu-bindings, you can use [get_cpu_bind_aurora](https://github.com/argonne-lcf/pbs_utils/blob/main/get_cpu_bind_aurora). Please see [User Guide for Aurora CPU Binding Script](https://github.com/argonne-lcf/pbs_utils/blob/main/doc/guide-get_cpu_bind_aurora.md) for documentation. 
 
 ### <a name="Binding-MPI-ranks-to-GPUs"></a>Binding MPI ranks to GPUs
 Support in MPICH on Aurora to bind MPI ranks to GPUs is currently work-in-progress. For applications that need this support, this instead can be handled by use of a small helper script that will appropriately set `ZE_AFFINITY_MASK` for each MPI rank. Users are encouraged to use the `/soft/tools/mpi_wrapper_utils/gpu_tile_compact.sh` script for instances where each MPI rank is to be bound to a single GPU tile with a round-robin assignment.
@@ -446,7 +447,8 @@ qsub -I -l select=1,walltime=1:00:00,place=scatter -A <MYPROJECT> -q debug
 
 This command requests 1 node for a period of 1 hour in the `workq` queue. After waiting in the queue for a node to become available, a shell prompt on a compute node will appear. You may then start building applications and testing gpu affinity scripts on the compute node.
 
-**NOTE:** If you want to `ssh` or `scp` to one of your assigned compute nodes you will need to make sure your `$HOME` directory and your `$HOME/.ssh` directory permissions are both set to `700`.
+!!! warning
+	If you want to `ssh` or `scp` to one of your assigned compute nodes you will need to make sure your `$HOME` directory and your `$HOME/.ssh` directory permissions are both set to `700`.
 
 
 ## <a name="Running-with-Multiple-CCS"></a>Running with Multiple Compute Command Streamers (CCSs)

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -420,6 +420,7 @@ This command requests 1 node for a period of 1 hour in the `workq` queue. After 
 
 The Intel PVC GPUs contain 4 Compute Command Streamers (CCSs) on each tile, which can be used to group Execution Units (EUs) into common pools. 
 These pools can then be accessed by separate processes thereby allowing users to bind multiple processes to a single tile and enabling applications to run up to 48 MPI processes per node on the 6 PVC available.
+Enabling multiple CCSs on Aurora is similar to the MPS capabilities on NVIDIA GPUs.
 By default, all EUs are assigned to a single CCS, but EUs can be distributed equally into 2 or 4 groups by exposing 2 or 4 CCSs, respectively. 
 This feature is enabled with the `ZEX_NUMBER_OF_CCS` environment variable, which takes a comma-separated list of device-mode pairs.
 For example, to enable 4 CCSs on all 6 PVC, execute


### PR DESCRIPTION
- Add a general section on using multiple CCS on the "Running Jobs on Aurora" page
- Added instructions about distributed training with multiple CCS in the PyTorch page