### PR TITLE
Fix Python docs on Aurora/Polaris; fix Aurora > Containers

### DIFF
--- a/docs/aurora/containers/containers.md
+++ b/docs/aurora/containers/containers.md
@@ -61,7 +61,7 @@ export HTTPS_PROXY="http://proxy.alcf.anl.gov:3128"
 export http_proxy="http://proxy.alcf.anl.gov:3128"
 export https_proxy="http://proxy.alcf.anl.gov:3128"
 export ftp_proxy="http://proxy.alcf.anl.gov:3128"
-export no_proxy="admin,polaris-adminvm-01,localhost,*.cm.polaris.alcf.anl.gov,polaris-*,*.polaris.alcf.anl.gov,*.alcf.anl.gov"
+export no_proxy="admin,*.hostmgmt.cm.aurora.alcf.anl.gov,*.alcf.anl.gov,localhost"
 
 # Load apptainer
 module load spack-pe-gcc

--- a/docs/aurora/containers/containers.md
+++ b/docs/aurora/containers/containers.md
@@ -51,7 +51,7 @@ apptainer exec docker://ghcr.io/apptainer/lolcow cowsay 'Fresh from the internet
 ### Example to run Postgres Database using Apptainer
 To run Postgres on Aurora compute node, below is a full example.
 
-```bash linenums="1"
+```bash linenums="1" title="apptainer_aurora_example.sh"
 # qsub from a UAN/login node
 qsub -l select=1 -l walltime=60:00 -A <Projectname> -q <Queue> -I
 
@@ -99,3 +99,4 @@ apptainer exec \
 # Stop the container and kill the process
 kill "$(cat pg_pid.txt)"
 rm pg_pid.txt
+```

--- a/docs/aurora/data-science/python.md
+++ b/docs/aurora/data-science/python.md
@@ -37,6 +37,10 @@ encounter a scenario in which you need to extend the functionality of the
 environment (i.e. install additional packages).
 In this case, we suggest the use of Python virtual environments. 
 
+!!! warning
+	
+	There are several alternative approaches for extending or modifying the base Anaconda environments that are generally not recommended on ALCF machines. On Aurora, there are additional performance and functionality pitfalls with those approaches. More detailed information on the alternatives can be seen on the [Polaris Python documentation](../../polaris/data-science/python.md).
+
 Creating and activating a new virtual environment (`venv`) is straightforward:
 
 ```bash

--- a/docs/polaris/data-science/python.md
+++ b/docs/polaris/data-science/python.md
@@ -55,7 +55,7 @@ To install a different version of a package that is already installed in the
 base environment, you can use:
 
 ```bash
-python3 pip install --ignore-installed <package> # or -I
+python3 -m pip install --ignore-installed <package> # or -I
 ```
 
 The shared base environment is not writable, so it is impossible to remove or
@@ -94,7 +94,7 @@ where, `#!bash path/to/envs/base-clone` should be replaced by a suitably path. T
     This is typically _not_ recommended.
 
 With the conda environment setup, one can install common Python modules using
-`#!bash python3 pip install --users '<module-name>'` which will install
+`#!bash python3 -m pip install --users '<module-name>'` which will install
 packages in `#!bash $PYTHONUSERBASE/lib/pythonX.Y/site-packages`.
 
 The `#!bash $PYTHONUSERBASE` environment variable is automatically set when you


### PR DESCRIPTION
Argo fixed  the `python3 pip ...` typos in the Sophia docs in #564, but it appears the upstream Polaris pages werent proofread. 

- [x] Fix containers proxy env vars that still reference Polaris