### PR TITLE
fixed some typos on the daos docs

### DIFF
--- a/docs/aurora/data-management/daos/daos-overview.md
+++ b/docs/aurora/data-management/daos/daos-overview.md
@@ -109,7 +109,7 @@ clush --hostfile ${PBS_NODEFILE} ps –ef | grep agent | grep -v grep'  | dshbak
 export DAOS_POOL=Your_allocated_pool_name
 daos pool query ${DAOS_POOL}
 daos cont list ${DAOS_POOL}
-daos container get-prop  $DAOS_POOL_NAME  $DAOS_CONT_NAME 
+daos container get-prop  $DAOS_POOL  $DAOS_CONT
 
 ```
 
@@ -117,8 +117,8 @@ daos container get-prop  $DAOS_POOL_NAME  $DAOS_CONT_NAME
 * Look for messages like `Health (status) : UNCLEAN in the get prop`
 
 ```bash
-daos pool      autotest  $DAOS_POOL_NAME 
-daos container check --pool=$DAOS_POOL_NAME --cont=$DAOS_CONT_NAME 
+daos pool      autotest  $DAOS_POOL
+daos container check --pool=$DAOS_POOL --cont=$DAOS_CONT
 ```
 
 ### Mount a POSIX container
@@ -130,17 +130,17 @@ In the future, we hope to automate some of this via additional `qsub` options.
 
 ```bash
 
-mkdir –p /tmp/${DAOS_POOL}/${DAOS_CONT}
-start-dfuse.sh -m /tmp/${DAOS_POOL}/${DAOS_CONT} --pool ${DAOS_POOL} --cont ${DAOS_CONT} # To mount
+mkdir –p /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}
+start-dfuse.sh -m /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT} --pool ${DAOS_POOL} --cont ${DAOS_CONT} # To mount
 mount | grep dfuse # To confirm if its mounted
 
 # Mode 1
-ls /tmp/${DAOS_POOL}/${DAOS_CONT} 
-cd /tmp/${DAOS_POOL}/${DAOS_CONT} 
-cp ~/temp.txt ~ /tmp/${DAOS_POOL}/${DAOS_CONT}/ 
-cat /tmp/${DAOS_POOL}/${DAOS_CONT}/temp.txt
+ls /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT} 
+cd /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT} 
+cp ~/temp.txt ~ /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}/ 
+cat /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}/temp.txt
 
-fusermount3 -u /tmp/${DAOS_POOL}/${DAOS_CONT} # To unmount
+fusermount3 -u /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT} # To unmount
 ```
  
 #### To mount a POSIX container on Compute Nodes
@@ -148,12 +148,12 @@ fusermount3 -u /tmp/${DAOS_POOL}/${DAOS_CONT} # To unmount
 You need to mount the container on all compute nodes.
 
 ```bash
-launch-dfuse.sh ${DAOS_POOL_NAME}:${DAOS_CONT_NAME} # launched using pdsh on all compute nodes mounted at: /tmp/<pool>/<container>
+launch-dfuse.sh ${DAOS_POOL}:${DAOS_CONT} # launched using pdsh on all compute nodes mounted at: /tmp/<pool>/<container>
 mount | grep dfuse # To confirm if its mounted
 
 ls /tmp/${DAOS_POOL}/${DAOS_CONT}/
 
-clean-dfuse.sh  ${DAOS_POOL_NAME}:${DAOS_CONT_NAME} # To unmount on all nodes 
+clean-dfuse.sh  ${DAOS_POOL}:${DAOS_CONT} # To unmount on all nodes 
 ```
 DAOS Data mover instruction is provided at [here](../moving_data_to_aurora/daos_datamover.md).
 
@@ -236,11 +236,12 @@ daos container get-prop  ${DAOS_POOL}  ${DAOS_CONT} #optional
 daos container list      ${DAOS_POOL}               #optional
 launch-dfuse.sh ${DAOS_POOL}:${DAOS_CONT}           # To mount on a compute node 
 
-# mkdir -p /tmp/${DAOS_POOL}/${DAOS_CONT}           # To mount on a login node
-# start-dfuse.sh -m /tmp/${DAOS_POOL}/${DAOS_CONT}     --pool ${DAOS_POOL} --cont ${DAOS_CONT}  # To mount on a login node
+# mkdir -p /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}           # To mount on a login node
+# start-dfuse.sh -m /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}     --pool ${DAOS_POOL} --cont ${DAOS_CONT}  # To mount on a login node
 
 mount|grep dfuse                                    #optional
-ls /tmp/${DAOS_POOL}/${DAOS_CONT}                   #optional
+ls /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}	        #optional for login node
+ls /tmp/${DAOS_POOL}/${DAOS_CONT}                   #optional for compute node
 
 # cp /lus/flare/projects/CSC250STDM10_CNDA/kaushik/thundersvm/input_data/real-sim_M100000_K25000_S0.836 /tmp/${DAOS_POOL}/${DAOS_CONT} #one time
 # daos filesystem copy --src /lus/flare/projects/CSC250STDM10_CNDA/kaushik/thundersvm/input_data/real-sim_M100000_K25000_S0.836 --dst daos://tmp/${DAOS_POOL}/${DAOS_CONT}  # check https://docs.daos.io/v2.4/testing/datamover/ 
@@ -270,7 +271,7 @@ LD_PRELOAD=/usr/lib64/libpil4dfs.so mpiexec -np ${NRANKS} -ppn ${RANKS_PER_NODE}
 date
 
 clean-dfuse.sh ${DAOS_POOL}:${DAOS_CONT} #to unmount on compute node
-# fusermount3 -u /tmp/${DAOS_POOL}/${DAOS_CONT} #to unmount on login node
+# fusermount3 -u /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT} #to unmount on login node
 
 ```
  
@@ -325,8 +326,8 @@ int main(int argc, char **argv)
     dfs_t *dfs;
     d_iov_t global;
     ret = MPI_Init(&argc, &argv);   
-    ret = MPI_Comm_rank(MPI_COMM_WORLD, &rank);    
-    ret = dfs_init();    
+    ret = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    ret = dfs_init();  
     ret = dfs_connect(getenv("DAOS_POOL"), NULL, getenv("DAOS_CONT"), O_RDWR, NULL, &dfs);    
     ret = dfs_open(dfs, NULL, filename, S_IFREG|S_IRUSR|S_IWUSR,  O_CREAT|O_WRONLY,  obj_class, chunk_size, NULL, &obj);
     ret = dfs_write(dfs, obj, &sgl, off, NULL);


### PR DESCRIPTION
updated ${DAOS_POOL_NAME} to ${DAOS_POOL} to make it consistent.

Added ${USER} on the login node mounts, so that the users don't step on other user mounts. This would result in permission errors. 
ls /tmp/${USER}/${DAOS_POOL}/${DAOS_CONT}