### PR TITLE
Adding initial page on Codee tool

### DIFF
--- a/docs/aurora/debugging/codee.md
+++ b/docs/aurora/debugging/codee.md
@@ -1,6 +1,6 @@
 # Using Codee to analyze Fortran code for correctness and modernization 
 
-The Codee tool automatically analyzes your code line by line to identify and fix opportunities for correctness, modernization, security and optimization. 
+The Codee tool automatically analyzes your code line-by-line to identify and fix opportunities for correctness, modernization, security and optimization. 
 
 ## Load the tool
 

--- a/docs/aurora/debugging/codee.md
+++ b/docs/aurora/debugging/codee.md
@@ -4,7 +4,7 @@ The Codee tool automatically analyzes your code line by line to identify and fix
 
 ## Load the tool
 
-```
+```bash linenums="1"
 module use /soft/modulefiles
 module load codee/2025.1
 ```

--- a/docs/aurora/debugging/codee.md
+++ b/docs/aurora/debugging/codee.md
@@ -1,0 +1,12 @@
+# Using Codee to analyze Fortran code for correctness and modernization 
+
+The Codee tool automatically analyzes your code line by line to identify and fix opportunities for correctness, modernization, security and optimization. 
+
+## Load the tool
+
+```
+module use /soft/modulefiles
+module load codee/2025.1
+```
+
+There is documentation, including quickstarts here: https://docs.codee.com/

--- a/docs/aurora/debugging/debugging-overview.md
+++ b/docs/aurora/debugging/debugging-overview.md
@@ -5,3 +5,7 @@ There are 3 debuggers available on Aurora:
 1. [gdb-oneapi](./gdb-oneapi.md) - This is Intel's version of gdb augmented to allow debugging kernels executing on the PVC GPUs.
 2. [DDT](./ddt-aurora.md) - The Linaro parallel debugger. This is the same parallel debugger that we have on Polaris. It supports a client-server mode and (via using `gdb-oneapi` internally) debugging kernels executing on the PVC GPUs.
 3. [gdb4hpc](./gdb4hpc.md) - An alternative for CPU debugging only that will apply commands to all threads in the MPI process group.
+
+There is also a correctness tool for Fortran:
+
+1. [Codee](./codee.md)

--- a/docs/aurora/debugging/debugging-overview.md
+++ b/docs/aurora/debugging/debugging-overview.md
@@ -8,4 +8,4 @@ There are 3 debuggers available on Aurora:
 
 There is also a correctness tool for Fortran:
 
-1. [Codee](./codee.md)
+1. [Codee](./codee.md) - This is a tool from Codee which can automatically analyze your code line-by-line to identify and fix opportunities for correctness, modernization, security and optimization. It is especially useful for legacy Fortran codes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,7 +251,7 @@ nav:
           - gdb-oneapi: aurora/debugging/gdb-oneapi.md
           - DDT: aurora/debugging/ddt-aurora.md
           - gdb4hpc: aurora/debugging/gdb4hpc.md
-          - codee: aurora/debugging/codee.md
+          - Codee: aurora/debugging/codee.md
         - Performance Tools:
         #  - Overview: aurora/performance-tools/performance-overview.md
           - Advisor: aurora/performance-tools/advisor.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,7 +251,7 @@ nav:
           - gdb-oneapi: aurora/debugging/gdb-oneapi.md
           - DDT: aurora/debugging/ddt-aurora.md
           - gdb4hpc: aurora/debugging/gdb4hpc.md
-	  - codee: aurora/debugging/codee.md
+          - codee: aurora/debugging/codee.md
         - Performance Tools:
         #  - Overview: aurora/performance-tools/performance-overview.md
           - Advisor: aurora/performance-tools/advisor.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,6 +251,7 @@ nav:
           - gdb-oneapi: aurora/debugging/gdb-oneapi.md
           - DDT: aurora/debugging/ddt-aurora.md
           - gdb4hpc: aurora/debugging/gdb4hpc.md
+	  - codee: aurora/debugging/codee.md
         - Performance Tools:
         #  - Overview: aurora/performance-tools/performance-overview.md
           - Advisor: aurora/performance-tools/advisor.md


### PR DESCRIPTION
This adds a brief initial page about the availability of Codee on Aurora.