### PR TITLE
Update csl.md

### DIFF
--- a/docs/ai-testbed/cerebras/csl.md
+++ b/docs/ai-testbed/cerebras/csl.md
@@ -124,7 +124,7 @@ Use the following `compile.py` script to compile the code in the respective exam
 
 ```python title="compile.py" linenums="1"
 import json
-from cerebras_appliance.sdk import SdkCompiler
+from cerebras.sdk.client import SdkCompiler
 
 # Instantiate copmiler
 compiler = SdkCompiler()
@@ -175,8 +175,8 @@ import os
 
 import numpy as np
 
-from cerebras_appliance.pb.sdk.sdk_common_pb2 import MemcpyDataType, MemcpyOrder
-from cerebras_appliance.sdk import SdkRuntime
+from cerebras.appliance.pb.sdk.sdk_common_pb2 import MemcpyDataType, MemcpyOrder
+from cerebras.sdk.client import SdkRuntime
 
 # Matrix dimensions
 M = 4


### PR DESCRIPTION
Updated imports based on docs https://sdk.cerebras.net/appliance-mode.

I followed the guide to a tee until I got compilation errors. Then I went to the Cerebras docs on running the SDK on the hardware (see link above). With just changing the imports, the example works for me on WSE2.