### PR TITLE
pbs qsub is not supported from login nodes.

### DIFF
--- a/docs/ai-testbed/groq/running-a-model-or-program.md
+++ b/docs/ai-testbed/groq/running-a-model-or-program.md
@@ -1,6 +1,6 @@
 # Running a Model/Program
 
-Jobs are launched from any GroqRack node, or from login nodes. <br>
+Jobs are launched from any GroqRack node. <br>
 If you expect a loss of an internet connection for any reason, for long-running jobs we suggest logging into a specific node and using either **screen** or **tmux** to create persistent command line sessions.  For details use:
 
 ```bash


### PR DESCRIPTION
Minor correction; qsub is not fully support from groq login nodes, so tell users to use it from groq nodes. 