### PR TITLE
fix: Fix padding below links in header

### DIFF
--- a/docs/stylesheets/alcf-extra.css
+++ b/docs/stylesheets/alcf-extra.css
@@ -408,7 +408,7 @@
   grid-column: span 6;
   grid-row: 3;
   position: relative;
-  height: 16px;
+  height: auto;
 }
 
 .header--primary .header__nav-primary ul {


### PR DESCRIPTION
- Old:
  
  ![old: tight spacing](https://github.com/user-attachments/assets/e19b8bb3-bcc8-4771-9fe0-e1082f9a145c) 

- New:

  ![new: more spacing](https://github.com/user-attachments/assets/366db210-742d-481b-b990-6c9af0097d0c)
