### PR TITLE
fix: Fix missing logo in mobile sidebar

### DIFF
--- a/overrides/partials/logo.html
+++ b/overrides/partials/logo.html
@@ -1,5 +1,0 @@
-<!-- Logo -->
-
-<!-- <a href="https://alcf.anl.gov/" title="ALCF User Guide" class="md-nav__button md-logo" aria-label="ALCF User Guide" data-md-component="logo"> -->
-<!--   <img src="{{ config.site_url }}/images/Argonne_wireframe_white_transparent.png" alt="logo"> -->
-<!-- </a> -->


### PR DESCRIPTION
Fixes missing logo in mobile sidebar

- Old:

  ![old-missing-logo](https://github.com/user-attachments/assets/553bb03d-b883-451f-82aa-77b19881f93b)

- New:

  ![new-fixed-logo](https://github.com/user-attachments/assets/c0f73472-900d-4847-8075-aeb1bfaea641)

## Copilot Summary

This pull request includes a small change to the `overrides/partials/logo.html` file. The change involves removing commented-out HTML code that was previously used for the logo. This cleanup helps to maintain a cleaner codebase.