### PR TITLE
Fix Issue template chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,19 @@
-blank_issues_enabled: true
+#blank_issues_enabled: true
 contact_links:
-  - name: ALCF Documentation Website
+  - name: ALCF Users Slack Workspace
+    url: https://alcf-users.slack.com/
+    about: User community for discussion, collaboration, and assistance. This pilot program is only open to select users, see [here](https://docs.alcf.anl.gov/contacting-support/alcf-users-slack/) for details
+  - name: ALCF Support (Open a Ticket)
+    url: mailto:support@alcf.anl.gov
+    about: For technical user support issues or questions after reading the user-guides, our ALCF Support team is available from 9 a.m. to 5 p.m. Central Time, Monday - Friday, except on holidays.
+  - name: ALCF Service Desk (Accounts Issues)
+    url: mailto:accounts@alcf.anl.gov
+    about: Contact ALCF support directly for account-related questions.
+  - name: ALCF Homepage
+    url: https://www.alcf.anl.gov/
+  - name: MyALCF Account Management
+    url: https://my.alcf.anl.gov/
+    about: For self-management of ALCF account, allocations, and project membership.
+  - name: ALCF User Guides
     url: https://docs.alcf.anl.gov/
     about: Check the official documentation first to see if your question is already answered.
-  - name: ALCF Support
-    url: https://www.alcf.anl.gov/support-center
-    about: Contact ALCF support directly for urgent issues or account-related questions. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 <details>
 <summary>Before</summary>
 
-<!-- Add your "before" screenshots here -->
+<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->
 
 </details>
 
@@ -17,7 +17,7 @@
 </details>
 
 ## Related Issue(s)
-<!-- If this PR is related to an issue, please link it here -->
+<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->
 
 ## Type of Change
 <!-- Please check the one that applies to this PR using "x". -->

--- a/overrides/partials/toc.html
+++ b/overrides/partials/toc.html
@@ -26,7 +26,7 @@
       <br>
       <li class="md-nav__item">
         <hr>
-        <a href="https://github.com/argonne-lcf/user-guides/issues/new" class="md-nav__link">
+        <a href="https://github.com/argonne-lcf/user-guides/issues/new/choose" class="md-nav__link">
           <span class="md-ellipsis">
             <strong>Does this doc need an update?<br>Open an Issue on GitHub</strong>
           </span>


### PR DESCRIPTION
## Description
Fix the MyALCF, etc. links on the Issue template chooser from. Also update the link to Open an Issue on the docs website

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here -->
Follow up from #804 

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update
- [ ] Bug fix
- [x] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
