### PR TITLE
fix: Update default fg color in dark theme

### DIFF
--- a/docs/stylesheets/alcf-extra.css
+++ b/docs/stylesheets/alcf-extra.css
@@ -58,20 +58,14 @@
 }
 
 [data-md-color-scheme="slate"] {
-  /* --md-typeset-a-color: #18B9B4; */
-  /* --md-typeset-a-color: rgb(184, 226, 255); */
-  /* --md-typeset-a-color: rgb(55, 176, 241); */
   --md-typeset-a-color: rgb(100, 226, 255);
-  --md-default-heading-color: #eeeeee;
+  --md-default-heading-color: #f5f5f5;
   --md-primary-fg-color: #222222;
   --md-default-bg-color: #1c1c1c;
   --md-header-bg-color: #222222;
-  --md-header-fg-color: #cccccc;
-  /* --md-primary-fg-color: #1A1C23; */
-  /* --md-default-bg-color: #111317; */
-  /* --md-header-bg-color: #1A1C23; */
+  --md-header-fg-color: #eeeeee;
+  --md-default-fg-color: #d7d7d7;
   --md-accent-fg-color: #18b9b4;
-  /* --md-default-bg-color: hsla(var(--md-hue), 15%, 14%, 1); */
   --md-default-fg-color: hsla(var(--md-hue), 15%, 90%, 0.82);
   --md-default-fg-color--light: hsla(var(--md-hue), 15%, 90%, 0.56);
   --md-default-fg-color--lighter: hsla(var(--md-hue), 15%, 90%, 0.32);
@@ -81,7 +75,6 @@
   --md-default-bg-color--lightest: hsla(var(--md-hue), 15%, 14%, 0.07);
   --md-code-fg-color: hsla(var(--md-hue), 18%, 86%, 0.82);
   --md-code-bg-color: #222222;
-  /*--md-code-bg-color: hsla(var(--md-hue), 15%, 18%, 1);*/
   --md-code-hl-color: #b8e2de;
   --md-code-hl-color--light: rgba(41, 119, 255, 0.2);
   --md-code-hl-number-color: #e6695b;
@@ -90,12 +83,6 @@
   --md-code-hl-constant-color: #9383e2;
   --md-code-hl-keyword-color: #6791e0;
   --md-code-hl-string-color: #2fb170;
-  /* --md-code-hl-name-color: var(--md-code-fg-color); */
-  /* --md-code-hl-operator-color: var(--md-default-fg-color--light); */
-  /* --md-code-hl-punctuation-color: var(--md-default-fg-color--light); */
-  /* --md-code-hl-comment-color: var(--md-default-fg-color--light); */
-  /* --md-code-hl-generic-color: var(--md-default-fg-color--light); */
-  /* --md-code-hl-variable-color: var(--md-default-fg-color--light); */
   --md-typeset-color: var(--md-default-fg-color);
   --md-typeset-kbd-color: hsla(var(--md-hue), 15%, 90%, 0.12);
   --md-typeset-kbd-accent-color: hsla(var(--md-hue), 15%, 90%, 0.2);
@@ -118,14 +105,31 @@
   max-width: 1440px;
 }
 
+/* .md-header { */
+/*   background-color: var(--md-header-bg-color); */
+/*   color: var(--md-header-fg-color); */
+/*   position: inherit; */
+/* } */
+
 .md-header {
   background-color: var(--md-header-bg-color);
+  box-shadow: 0 0 .2rem #0000, 0 .2rem .4rem #0000;
   color: var(--md-header-fg-color);
-  position: unset;
+  /* position: unset; */
 }
 
 .header--primary {
   position: revert;
+/* ||||||| Stash base */
+/*   position: inherit; */
+/* ======= */
+  display: block;
+  left: 0;
+  position: sticky;
+  right: 0;
+  top: 0;
+  z-index: 4;
+/* >>>>>>> Stashed changes */
 }
 
 .md-main__inner {
@@ -216,10 +220,13 @@
 /* primary header */
 /* ------------------------------------------------------------------------- */
 
-
-.header--primary .header__nav-secondary--right {
-  z-index: 100000000000000;
-}
+/* .header--primary .header__nav-secondary--right { */
+/*   z-index: 100000000000000; */
+/* } */
+/**/
+/* .header--primary .header__nav-secondary--right { */
+/*   z-index: 100000000000000; */
+/* } */
 
 /* hide material header at large sizes, and the alcf header at small sizes */
 @media only screen and (max-width: 1020px) {
@@ -265,12 +272,11 @@
     right: 0;
     display: inline-flex;
     margin: auto;
-    z-index: 100000000000000;
   }
 
-  .md-header {
-    z-index: unset;
-  }
+  /* .md-header { */
+  /*   z-index: unset; */
+  /* } */
 }
 
 .header--primary .header__nav-secondary ul {


### PR DESCRIPTION
## Description
- Updates default foreground text color in dark theme to have better contrast

## Screenshots (if applicable)
<details>
<summary>Before</summary>

![Screen Shot 2025-03-24 at 12 45 49](https://github.com/user-attachments/assets/d8d36e46-8e1c-4217-8088-827dc225a5cf)

</details>

<details>
<summary>After</summary>

![Screen Shot 2025-03-24 at 12 45 52](https://github.com/user-attachments/assets/e8e14936-5977-47f9-9c46-03e3453abb0e)

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update
- [ ] Bug fix
- [x] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
