### PR TITLE
fix: Update default fg color in dark theme (take 2)

### DIFF
--- a/docs/stylesheets/alcf-extra.css
+++ b/docs/stylesheets/alcf-extra.css
@@ -65,8 +65,8 @@
   --md-header-bg-color: #222222;
   --md-header-fg-color: #eeeeee;
   --md-default-fg-color: #d7d7d7;
+  /* --md-default-fg-color: hsla(var(--md-hue), 15%, 90%, 0.82); */
   --md-accent-fg-color: #18b9b4;
-  --md-default-fg-color: hsla(var(--md-hue), 15%, 90%, 0.82);
   --md-default-fg-color--light: hsla(var(--md-hue), 15%, 90%, 0.56);
   --md-default-fg-color--lighter: hsla(var(--md-hue), 15%, 90%, 0.32);
   --md-default-fg-color--lightest: hsla(var(--md-hue), 15%, 90%, 0.12);


### PR DESCRIPTION
## Description
- Updates default foreground text color in dark theme to have better contrast

## Screenshots (if applicable)
<details>
<summary>Before</summary>

![Screen Shot 2025-03-24 at 12 45 49](https://github.com/user-attachments/assets/d8d36e46-8e1c-4217-8088-827dc225a5cf)

</details>

<details>
<summary>After</summary>

![Screen Shot 2025-03-24 at 12 45 52](https://github.com/user-attachments/assets/e8e14936-5977-47f9-9c46-03e3453abb0e)

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update
- [ ] Bug fix
- [x] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
