### PR TITLE
Update known-issues.md to include possibility of GPU buffer issue

### DIFF
--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -150,6 +150,10 @@ PMIX ERROR: PMIX_ERROR in file dstore_base.c at line 2334
 
 These errors can be safely ignored.
 
+#### 6. Incorrect results in receive buffer in GPU memory 
+
+In the default mpich module on Aurora, it is possible to get incorrect results in GPU buffers passed through MPI calls. More detail are: [Issue#7302](https://github.com/pmodels/mpich/issues/7302). This will be fixed in the next mpich module upgrade. For now, be careful of using GPU buffers in MPI communications as you may get incorrect results. 
+
 ### Submitting Jobs
 
 Jobs may fail to successfully start at times (particularly at higher node counts). If no error message is apparent, then one thing to check is the `comment` field in the full job information for the job using the command `qstat -xfw <JOBID> | grep comment`. Some example comments follow.

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -152,7 +152,7 @@ These errors can be safely ignored.
 
 #### 6. Incorrect results in receive buffer in GPU memory 
 
-In the default mpich module on Aurora, it is possible to get incorrect results in GPU buffers passed through MPI calls. More detail are: [Issue#7302](https://github.com/pmodels/mpich/issues/7302). This will be fixed in the next mpich module upgrade. For now, be careful of using GPU buffers in MPI communications as you may get incorrect results. 
+In the default MPICH module on Aurora, it is possible to get incorrect results in GPU buffers passed through MPI calls. More detail are: [Issue#7302](https://github.com/pmodels/mpich/issues/7302). This will be fixed in the next MPICH module upgrade. For now, be careful of using GPU buffers in MPI communications as you may get incorrect results. 
 
 ### Submitting Jobs
 


### PR DESCRIPTION
## Description
This is to include a new known issue, related to issues with incorrect answers if GPU buffers are used in MPI.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [X] Documentation content update
- [ ] Bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [X] I have added at least one Label to this PR
