### PR TITLE
Update 3x submodules every day, early AM

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,0 +1,25 @@
+name: Update Submodules
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # 3 AM CDT (8 AM UTC)
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-submodules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+
+      - name: Update submodules
+        run: |
+          git submodule update --remote --merge
+          git add .
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "chore: update submodules" || echo "No changes to commit"
+          git push 

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -205,6 +205,6 @@ To increase the chances that a large job does not terminate due to a node failur
 
 The repository [argonne-lcf/AuroraBugTracking](https://github.com/argonne-lcf/AuroraBugTracking) is a public bug tracking system for known issues (and recently resolved bugs) that affect production science on ALCF Aurora. To report an issue, please reach out to [ALCF Support](../support/technical-support.md).
 
-For convenience, a recent copy of the summary tables are included here. For the latest versions, see [`bugs.md`](https://github.com/argonne-lcf/AuroraBugTracking/blob/main/bugs.md)
+For convenience, nightly (sortable) copies of the summary tables are included here. For the latest versions, see [`bugs.md`](https://github.com/argonne-lcf/AuroraBugTracking/blob/main/bugs.md)
 
 ---8<--- "AuroraBugTracking/bugs.md:2"


### PR DESCRIPTION
## Description

This way, we get the nearly-latest versions of the Aurora bug table embedded in https://docs.alcf.anl.gov/aurora/known-issues/#aurora-bug-tracking-repository-and-table

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update
- [ ] Bug fix
- [x] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
