### PR TITLE
Aurora: scaling out of shared filesystems

### DIFF
--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -42,7 +42,7 @@ Applications which dynamically load libraries out of shared filesystems such as 
 
 - Use software in the Aurora PE (`/opt/aurora`) whenever possible, as this avoids dependence on shared filesystems entirely.
 - Statically link application binaries, as this reduces the number of dynamically loaded files.
-- If loading many small (≲100MB) files, use [Copper](data-management/copper/copper.md).
+- If loading many small (≲100MB) shared libraries or Python modules, use [Copper](data-management/copper/copper.md).
 
 ### Checkpointing
 

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -36,7 +36,7 @@ The performance of DAOS has been impressive, but we continue to experience crash
 
 These won’t be mounted on Aurora initially, but they might be mounted around May 2025, depending on feasibility. Similarly, Flare will not initially be mounted on Polaris. DTNs and [Globus](../data-management/data-transfer/using-globus.md) are the best means to transfer data between Polaris and Aurora.
 
-### Scaling out of lustre and /soft
+### Scaling out of Flare (Lustre) and `/soft` (NFS)
 
 Applications which dynamically load libraries out of shared filesystems such as Flare or `/soft` may experience performance impacts when scaling to large numbers of nodes. These guidelines may mitigate some of these scaling impacts:
 

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -36,6 +36,14 @@ The performance of DAOS has been impressive, but we continue to experience crash
 
 These won’t be mounted on Aurora initially, but they might be mounted around May 2025, depending on feasibility. Similarly, Flare will not initially be mounted on Polaris. DTNs and [Globus](../data-management/data-transfer/using-globus.md) are the best means to transfer data between Polaris and Aurora.
 
+### Scaling out of lustre and /soft
+
+Applications which dynamically load libraries out of shared filesystems such as Flare or `/soft` may experience performance impacts when scaling to large numbers of nodes. These guidelines may mitigate some of these scaling impacts:
+
+- Use software in the Aurora PE (`/opt/aurora`) whenever possible, as this avoids dependence on shared filesystems entirely.
+- Statically link application binaries, as this reduces the number of dynamically loaded files.
+- If loading many small (≲100MB) files, use [Copper](data-management/copper/copper.md).
+
 ### Checkpointing
 
 Checkpointing is absolutely essential. The mean time between application interrupts caused by system instability may be as short as an hour for larger jobs. The frequency of checkpointing is something that needs to be decided for each individual application based on the scale of runs:


### PR DESCRIPTION
## Description
Add a section in the Known Issues page of the Aurora documentation to give guidance on best practices for scaling out of shared filesystems.

## Screenshots (if applicable)
<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/378a9800-0151-4276-816f-a1405a93c05c)

</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/63776b8f-ef70-4922-89d5-69a5dd12b36c)

</details>

## Related Issue(s)
N/A

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update
- [ ] Bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
