### PR TITLE
Using ZE_AFFINITY_MASK with the Frameworks module

### DIFF
--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -370,23 +370,15 @@ Users with different MPI-GPU affinity needs, such as assigning multiple GPUs/til
 
 One example below shows a common mapping of MPI ranks to cores and GPUs.
 
-The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, so if you wish to bind MPI ranks to devices instead of tiles, it can be done the following way:
+The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, treating each tile as a device, and bind ranks appropriately. 
+Our current recommendation is to __not__ use the `gpu_tile_compact.sh` script 
+during the job submission.
 
-```bash
-#!/bin/bash
-num_gpus=12
-gpu_id=$((PMIX_RANK % ${num_gpus} ))
-export ZE_AFFINITY_MASK=$gpu_id
-exec "$@"
-```
-Caution: This will narrow the affinity mask down and generate PyTorch warnings.
-
-A more verbose way of doing the bindings properly, while using the `frameworks`
-module would be to write the affinity explicitly in the job submission script
-
-```bash
-export ZE_AFFINITY_MASK="0,1,2,3,4,5,6,7,8,9,10,11"
-```
+If specific use cases require leveraging the device hierarchy differently, 
+special attention needs to be paid toward the effects of the narrowing of the 
+affinity mask, as some components of the `frameworks` expect full visibility of
+the available devices. A narrow affinity mask leads to PyTorch warnings and 
+caution must be exercised to proceed with this.  
 
 More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found in [Intel's online documentation](https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html).
 

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -26,7 +26,7 @@ There are four production queues you can target in your qsub (`-q <queue name>`)
 | medium          | 1025     | 2048     | 5 min    | 18 hrs   |                                                                                                    |
 | large           | 2048     | 10624    | 5 min    | 24 hrs   | ***Only accessible with access to prod-large queue***                                              |
 | backfill-tiny   | 32       | 512      | 5 min    | 6 hrs    | Low priority, negative project balance                                                             |
-| backfill-small  | 513      | 1024     | 5 min    | 12 hrs   | Low priority, negative project balance                                                             |
+| backfil_tl-small  | 513      | 1024     | 5 min    | 12 hrs   | Low priority, negative project balance                                                             |
 | backfill-medium | 1025     | 2048     | 5 min    | 18 hrs   | Low priority, negative project balance                                                             |
 | backfill-large  | 2049     | 10624    | 5 min    | 24 hrs   | ***Only accessible with access to prod-large queue*** <br/> Low priority, negative project balance |
 
@@ -339,7 +339,14 @@ Note that the threads MPI rank 6 are bound to cross both socket 0 and socket 1, 
 	For a script to help provide cpu-bindings, you can use [get_cpu_bind_aurora](https://github.com/argonne-lcf/pbs_utils/blob/main/get_cpu_bind_aurora). Please see [User Guide for Aurora CPU Binding Script](https://github.com/argonne-lcf/pbs_utils/blob/main/doc/guide-get_cpu_bind_aurora.md) for documentation. 
 
 ### <a name="Binding-MPI-ranks-to-GPUs"></a>Binding MPI ranks to GPUs
-Support in MPICH on Aurora to bind MPI ranks to GPUs is currently work-in-progress. For applications that need this support, this instead can be handled by use of a small helper script that will appropriately set `ZE_AFFINITY_MASK` for each MPI rank. Users are encouraged to use the `gpu_tile_compact.sh` script for instances where each MPI rank is to be bound to a single GPU tile with a round-robin assignment. `gpu_tile_compact.sh` should be in your path by default. Note that `gpu_tile_compact.sh` requires `ZE_FLAT_DEVICE_HIERARCHY`=`COMPOSITE` (the default in the environment). If you wish to bind MPI ranks to devices instead of tiles, `gpu_dev_compact.sh` (also in your path by default) can be used.
+Support in MPICH on Aurora to bind MPI ranks to GPUs is currently work-in-progress. 
+For applications that need this support, this instead can be handled by use of a small helper script that will appropriately set `ZE_AFFINITY_MASK` for each MPI rank.
+Users are encouraged to use the `gpu_tile_compact.sh` script for instances where each MPI rank is to be bound to a single GPU tile with a round-robin assignment. `gpu_tile_compact.sh` should be in your path by default. 
+
+Note that `gpu_tile_compact.sh` requires `ZE_FLAT_DEVICE_HIERARCHY`=`COMPOSITE` (the default in the environment).
+The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, so if you wish to bind MPI ranks to devices instead of tiles, `gpu_dev_compact.sh` (also in your path by default) can be used.
+
+More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found here: https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html
 
 This script can be placed just before the executable in an `mpiexec` command like so.
 

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -370,15 +370,18 @@ Users with different MPI-GPU affinity needs, such as assigning multiple GPUs/til
 
 One example below shows a common mapping of MPI ranks to cores and GPUs.
 
-The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, treating each tile as a device, and bind ranks appropriately. 
-Our current recommendation is to __not__ use the `gpu_tile_compact.sh` script 
-during the job submission.
+The `frameworks` module set the `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, treating each tile as a device.
+Our current recommendation is to __not__ use the `gpu_tile_compact.sh` script during the job submission while using the `frameworks` module. 
+If you wish to bind MPI ranks to devices instead of tiles, this can be done the following way:
 
-If specific use cases require leveraging the device hierarchy differently, 
-special attention needs to be paid toward the effects of the narrowing of the 
-affinity mask, as some components of the `frameworks` expect full visibility of
-the available devices. A narrow affinity mask leads to PyTorch warnings and 
-caution must be exercised to proceed with this.  
+```bash linenums="1"
+#!/bin/bash
+num_gpus=12
+gpu_id=$((PMIX_RANK % ${num_gpus} ))
+export ZE_AFFINITY_MASK=$gpu_id
+exec "$@"
+```
+Caution: This will narrow the affinity mask down and generate PyTorch warnings. If you want to avoid that, don't use this binding script and do the binding manually inside your apps. 
 
 More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found in [Intel's online documentation](https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html).
 

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -26,7 +26,7 @@ There are four production queues you can target in your qsub (`-q <queue name>`)
 | medium          | 1025     | 2048     | 5 min    | 18 hrs   |                                                                                                    |
 | large           | 2048     | 10624    | 5 min    | 24 hrs   | ***Only accessible with access to prod-large queue***                                              |
 | backfill-tiny   | 32       | 512      | 5 min    | 6 hrs    | Low priority, negative project balance                                                             |
-| backfil-small  | 513      | 1024     | 5 min    | 12 hrs   | Low priority, negative project balance                                                             |
+| backfill-small  | 513      | 1024     | 5 min    | 12 hrs   | Low priority, negative project balance                                                             |
 | backfill-medium | 1025     | 2048     | 5 min    | 18 hrs   | Low priority, negative project balance                                                             |
 | backfill-large  | 2049     | 10624    | 5 min    | 24 hrs   | ***Only accessible with access to prod-large queue*** <br/> Low priority, negative project balance |
 

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -346,7 +346,7 @@ Users are encouraged to use the `gpu_tile_compact.sh` script for instances where
 Note that `gpu_tile_compact.sh` requires `ZE_FLAT_DEVICE_HIERARCHY`=`COMPOSITE` (the default in the environment).
 The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, so if you wish to bind MPI ranks to devices instead of tiles, `gpu_dev_compact.sh` (also in your path by default) can be used.
 
-More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found here: https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html
+More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found in [Intel's online documentation](https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html). 
 
 This script can be placed just before the executable in an `mpiexec` command like so.
 

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -26,7 +26,7 @@ There are four production queues you can target in your qsub (`-q <queue name>`)
 | medium          | 1025     | 2048     | 5 min    | 18 hrs   |                                                                                                    |
 | large           | 2048     | 10624    | 5 min    | 24 hrs   | ***Only accessible with access to prod-large queue***                                              |
 | backfill-tiny   | 32       | 512      | 5 min    | 6 hrs    | Low priority, negative project balance                                                             |
-| backfil_tl-small  | 513      | 1024     | 5 min    | 12 hrs   | Low priority, negative project balance                                                             |
+| backfil-small  | 513      | 1024     | 5 min    | 12 hrs   | Low priority, negative project balance                                                             |
 | backfill-medium | 1025     | 2048     | 5 min    | 18 hrs   | Low priority, negative project balance                                                             |
 | backfill-large  | 2049     | 10624    | 5 min    | 24 hrs   | ***Only accessible with access to prod-large queue*** <br/> Low priority, negative project balance |
 

--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -344,9 +344,6 @@ For applications that need this support, this instead can be handled by use of a
 Users are encouraged to use the `gpu_tile_compact.sh` script for instances where each MPI rank is to be bound to a single GPU tile with a round-robin assignment. `gpu_tile_compact.sh` should be in your path by default. 
 
 Note that `gpu_tile_compact.sh` requires `ZE_FLAT_DEVICE_HIERARCHY`=`COMPOSITE` (the default in the environment).
-The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, so if you wish to bind MPI ranks to devices instead of tiles, `gpu_dev_compact.sh` (also in your path by default) can be used.
-
-More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found in [Intel's online documentation](https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html). 
 
 This script can be placed just before the executable in an `mpiexec` command like so.
 
@@ -372,6 +369,26 @@ exec "$@"
 Users with different MPI-GPU affinity needs, such as assigning multiple GPUs/tiles per MPI rank, are encouraged to modify a local copy of `gpu_tile_compact.sh` (`which gpu_tile_compact.sh` will show the location of the script) to suit their needs.
 
 One example below shows a common mapping of MPI ranks to cores and GPUs.
+
+The `frameworks` module set `ZE_FLAT_DEVICE_HIERARCHY=FLAT`, so if you wish to bind MPI ranks to devices instead of tiles, it can be done the following way:
+
+```bash
+#!/bin/bash
+num_gpus=12
+gpu_id=$((PMIX_RANK % ${num_gpus} ))
+export ZE_AFFINITY_MASK=$gpu_id
+exec "$@"
+```
+Caution: This will narrow the affinity mask down and generate PyTorch warnings.
+
+A more verbose way of doing the bindings properly, while using the `frameworks`
+module would be to write the affinity explicitly in the job submission script
+
+```bash
+export ZE_AFFINITY_MASK="0,1,2,3,4,5,6,7,8,9,10,11"
+```
+
+More information on `ZE_FLAT_DEVICE_HIERARCHY` can be found in [Intel's online documentation](https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html).
 
 #### Example 1: 1 node, 12 ranks/node, 1 thread/rank, 1 rank/GPU
 


### PR DESCRIPTION
## Description
<Added content in discussing how to use `ZE_AFFINITY_MASK` with the `frameworks` module which sets the
~ZE_DEVICE_HIERARCHY=FLAT`>

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
