### PR TITLE
fix a broken procedure for making a Cerebras virtual env. Appears to …

### DIFF
--- a/docs/ai-testbed/cerebras/customizing-environment.md
+++ b/docs/ai-testbed/cerebras/customizing-environment.md
@@ -4,6 +4,18 @@
 
 #### To make a PyTorch virtual environment for Cerebras
 
+Clone the Cerebras modelzoo, if it is not already cloned. Check out the R 2.4.0 release.
+
+```console
+mkdir ~/R_2.4.0
+cd ~/R_2.4.0
+git clone https://github.com/Cerebras/modelzoo.git
+cd modelzoo
+git tag
+git checkout Release_2.4.0
+```
+Then build the virtual environment
+
 ```console
 mkdir ~/R_2.4.0
 cd ~/R_2.4.0
@@ -14,7 +26,8 @@ rm -r venv_cerebras_pt
 source venv_cerebras_pt/bin/activate
 pip install --upgrade pip
 pip install cerebras_pytorch==2.4.0
-pip install --editable git+https://github.com/Cerebras/modelzoo#egg=cerebras_modelzoo 'murmurhash==1.0.10' 'thinc==8.2.2' 'cymem<2.0.10'
+pip install -r modelzoo/requirements.txt
+pip install 'murmurhash==1.0.10' 'thinc==8.2.2' 'cymem<2.0.10'
 ```
 
 <!--- No longer any TensorFlow wheel

--- a/docs/ai-testbed/cerebras/running-a-model-or-program.md
+++ b/docs/ai-testbed/cerebras/running-a-model-or-program.md
@@ -1,3 +1,4 @@
+
 # Running a Model/Program
 
 ## Getting Started
@@ -31,6 +32,8 @@ source ~/R_2.4.0/venv_cerebras_pt/bin/activate
 ```
 
 ### Clone the Cerebras modelzoo
+
+If you have not already cloned the Cerebras modelzoo repo and checked out the Release_2.4.0 tag, do so.
 
 ```console
 mkdir ~/R_2.4.0


### PR DESCRIPTION
…have broken with their R_2.5.0 release.

The previously documented procedure installed from the git repo at github.com. The fix is to clone the repo, change to the correct 2.4.0 tag, and install from the clone, using requirements.txt (2.4.3 and 2.5.0 use setup.py). 

