### PR TITLE
adding openai/gpt-oss 20b and 120b models

### DIFF
--- a/docs/services/inference-endpoints.md
+++ b/docs/services/inference-endpoints.md
@@ -301,6 +301,11 @@ For more examples, please see the [inference-endpoints GitHub repository](https:
 
     - allenai/Llama-3.1-Tulu-3-405B
 
+    **OpenAI Family**
+
+    - openai/gpt-oss-20b<sup>B</sup><sup>R</sup>
+    - openai/gpt-oss-120b<sup>B</sup><sup>R</sup>
+
     **Google Family**
 
     - google/gemma-3-27b-it<sup>B</sup><sup>T</sup>


### PR DESCRIPTION
## Description
Inference Endpoints documentation: Added 2 OpenAI models in the "Available Models" section

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
