### PR TITLE
Fix some urls that were changed by sambanova. Also, fix a malformed m…

### DIFF
--- a/docs/ai-testbed/sambanova/documentation.md
+++ b/docs/ai-testbed/sambanova/documentation.md
@@ -1,5 +1,5 @@
 # Documentation
 
-The SambaNova documentation is now available online [SambaNova Documentation](https://docs.sambanova.ai/developer/latest/sambaflow-intro.html).
+The SambaNova documentation is now available online [SambaNova Documentation](https://docs-legacy.sambanova.ai/developer/latest/sambaflow-intro.html).
 
-The documentation for the SambaTune (a profiling and performance tuning tool for SambaNova systems) is now available at [SambaTune Documentation](https://docs.sambanova.ai/sambatune/latest/index.html).
+The documentation for the SambaTune (a profiling and performance tuning tool for SambaNova systems) is now available at [SambaTune Documentation](https://docs-legacy.sambanova.ai/sambatune/latest/index.html).

--- a/docs/ai-testbed/sambanova/example-modelzoo-programs.md
+++ b/docs/ai-testbed/sambanova/example-modelzoo-programs.md
@@ -78,7 +78,7 @@ pip install -e .
 
 This model is also avaiable in `/software/models/Llama-2-7b-hf/`
 First, create a Hugging Face account at https://huggingface.co/join if you do not already have one.  
-Go to [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf[meta-llama/Llama-2-7b-hf) and accept the terms of use for Llama2 7B.  
+Go to [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf) and accept the terms of use for Llama2 7B.  
 You will need to wait (minutes at least) until the request is proccessed.  
 In your [Hugging Face account settings](https://huggingface.co/settings/tokens), generate a [user access token](link:https://huggingface.co/docs/hub/en/security-tokens). A read-only token works. Record the token such that it can easily be copy-pasted in the future.
 ```

--- a/docs/ai-testbed/sambanova/index.md
+++ b/docs/ai-testbed/sambanova/index.md
@@ -6,6 +6,6 @@ The SambaNova DataScale SN30 system is architected around the next-generation Re
 
 Below are some of the links to SambaNova documentation.
 
-SambaNova white paper: [Accelerated Computing with a Reconfigurable Dataflow Architecture](https://sambanova.ai/wp-content/uploads/2021/06/SambaNova_RDA_Whitepaper_English.pdf)
+SambaNova white paper: [Accelerated Computing with a Reconfigurable Dataflow Architecture](https://sambanova.ai/hubfs/23945802/SambaNova_Accelerated-Computing-with-a-Reconfigurable-Dataflow-Architecture_Whitepaper_English-1.pdf)
 
-SN30 documentation: [SambaNova Documentation](https://docs.sambanova.ai/home/latest/index.html)
+SN30 documentation: [SambaNova Documentation](https://docs-legacy.sambanova.ai/home/latest/index.html)

--- a/docs/ai-testbed/sambanova/sambatune.md
+++ b/docs/ai-testbed/sambanova/sambatune.md
@@ -58,7 +58,7 @@ You should now see the SambaTune UI. <br>
 If the browser does not show a login prompt, or if any previous step complains about a port conflict, try another value for ST_PORT on both the target node and for the ssh tunnel command, e.g. 8577.
 
 See SambaNova's SambaTune documentation for more information about using SambaTune and the SambaTune UI.<br>
-This section is a good starting point: [Workflow overview](https://docs.sambanova.ai/sambatune/latest/workflow.html)
+This section is a good starting point: [Workflow overview](https://docs-legacy.sambanova.ai/sambatune/latest/workflow.html)
 
 When finished:<br>
 - Break the ssh tunnel with ++ctrl+c++ (SIGINT) or equivalent.<br>


### PR DESCRIPTION
…arkdown link.

Sambanova shifted the SN30-related documentation to docs-legacy. Tracked this, and also fixed a link that was simply broken.
