### PR TITLE
Update known-issues.md to add message about too large files

### DIFF
--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -166,7 +166,7 @@ In the default MPICH module on Aurora, it is possible to get incorrect results i
 #### 7. File too large for Clang to processs
 
 If you see a compile error similar to:
-```
+```console
 error: file '/var/tmp/icpx-85f5cf3735/wrapper-a0fbdc.bc' is too large for Clang to process
 1 error generated.
 ```

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -163,6 +163,15 @@ These errors can be safely ignored.
 
 In the default MPICH module on Aurora, it is possible to get incorrect results in GPU buffers passed through MPI calls. More detail are: [Issue#7302](https://github.com/pmodels/mpich/issues/7302). This will be fixed in the next MPICH module upgrade. For now, be careful of using GPU buffers in MPI communications as you may get incorrect results. 
 
+#### 7. File too large for Clang to processs
+
+If you see a compile error similar to:
+```
+error: file '/var/tmp/icpx-85f5cf3735/wrapper-a0fbdc.bc' is too large for Clang to process
+1 error generated.
+```
+when you are compiling with `-g`, you can decrease the size of the files by compiling with `-fno-system-debug -g`.
+
 ### Submitting Jobs
 
 Jobs may fail to successfully start at times (particularly at higher node counts). If no error message is apparent, then one thing to check is the `comment` field in the full job information for the job using the command `qstat -xfw <JOBID> | grep comment`. Some example comments follow.

--- a/docs/aurora/known-issues.md
+++ b/docs/aurora/known-issues.md
@@ -170,7 +170,7 @@ If you see a compile error similar to:
 error: file '/var/tmp/icpx-85f5cf3735/wrapper-a0fbdc.bc' is too large for Clang to process
 1 error generated.
 ```
-when you are compiling with `-g`, you can decrease the size of the files by compiling with `-fno-system-debug -g`.
+when you are compiling with `-g`, you can decrease the size of the files by compiling with `-fno-system-debug -g`. See [Intel documentation](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2025-2/fsystem-debug.html) for more details.
 
 ### Submitting Jobs
 


### PR DESCRIPTION
## Description
As discussed in a bug meeting, we wanted to add a known issue about too large files during compile.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
