### PR TITLE
docs: Fix code background-color in dark theme

### DIFF
--- a/docs/stylesheets/alcf-extra.css
+++ b/docs/stylesheets/alcf-extra.css
@@ -453,7 +453,6 @@
   --md-code-hl-keyword-color:     var(--blue_med); 
   --md-code-hl-string-color:      var(--green_med);
 
-
   body {
     color: var(--neutral-med-light);
     transition: color .25s, background-color .25s;
@@ -649,9 +648,13 @@
     background-color: var(--neutral_med-light);
   }
 
-  .md-typeset code {
-    background-color: var(--neutral_med-light);
-    color: var(--neutral_dark);
+  /* .md-typeset code { */
+  /*   background-color: var(--neutral_med-light); */
+  /*   color: var(--neutral_dark); */
+  /* } */
+  & .md-typeset code {
+      background-color: var(--neutral_med-dark);
+      color: var(--neutral_med-light);
   }
 
   .md-typeset a code {
@@ -1193,7 +1196,7 @@
 
 .header--primary .header__nav-secondary li,
 .header--primary .header__nav-primary li {
-  padding-bottom: 9px;
+  padding-bottom: 8px;
   display: inline;
 }
 


### PR DESCRIPTION
## Description

Fix code background color in dark theme to match background

## Screenshots
<details>
<summary>Before</summary>

<img width="2196" height="1394" alt="Screen Shot 2025-10-07 at 22 25 18" src="https://github.com/user-attachments/assets/262c0e80-3526-48ee-bb5a-4d53b3367aa5" />


</details>

<details>
<summary>After</summary>

<img width="2196" height="1394" alt="Screen Shot 2025-10-07 at 22 25 19" src="https://github.com/user-attachments/assets/b0d49f7e-7b0a-48b5-bc0b-942ba2d89159" />


</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [x] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR


## Copilot Summary

This pull request makes minor adjustments to the `alcf-extra.css` stylesheet, primarily refining the appearance of inline code blocks and navigation headers.

Styling updates:

* Updated the background and text color for inline code blocks within `.md-typeset`, improving contrast and readability. The old rule was commented out and replaced with a new one.
* Adjusted the padding for navigation header list items from 9px to 8px for a slightly more compact layout.

Other:

* Removed an unnecessary blank line for minor code cleanliness.