### PR TITLE
change names of models served by a metis endpoint

### DIFF
--- a/docs/ai-testbed/sn40l_inference/using_an_inference_endpoint.md
+++ b/docs/ai-testbed/sn40l_inference/using_an_inference_endpoint.md
@@ -34,7 +34,7 @@ The files can be sourced to set environment variables, e.g. if the endpoint were
 source ~/metis_endpoint_endpoint_1.txt
 ```
 
-Endpoint "metis_endpoint_1" serves the "DeepSeek-R1" model. Endpoint "metis_endpoint_2" serves the "Llama-4-Maverick-17B-128E-Instruct" model.
+Endpoint "metis_endpoint_1" serves the "DeepSeek-R1" model. Endpoint "metis_endpoint_2" serves the "Meta-Llama-3.3-70B-Instruct", "Meta-Llama-3.1-8B-Instruct", and "Qwen2.5-Coder-0.5B-Instruct" models.
 If you need any other models to be provisioned via these endpoints, please reach out to support[at]alcf.anl.gov.
 
 See SambaNova's documentation for additional information to supplement the instructions below: [OpenAI compatible API](https://docs.sambanova.ai/sambastudio/latest/open-ai-api.html).


### PR DESCRIPTION
change names of models served by a metis endpoint. llama4-maverick was deprecated.