### PR TITLE
Updates for frameworks/2025.2.0 with PyTorch-2.8

### DIFF
--- a/docs/aurora/data-science/frameworks/pytorch.md
+++ b/docs/aurora/data-science/frameworks/pytorch.md
@@ -24,7 +24,7 @@ To use it from a compute node, please load the following modules:
 ```bash
 module load frameworks
 ```
-Then, you can `import` PyTorch in Python as usual (below showing results from the `frameworks/2024.2.1_u1`  module):
+Then, you can `import` PyTorch in Python as usual (below showing results from the `frameworks/2025.2.0`  module):
 ``` { .python .no-copy }
 >>> import torch
 >>> torch.__version__


### PR DESCRIPTION
## Description
Made a few changes related to the frameworks/2025.2.0 on branch kh_2p8:
- Removed torch_ccl, noftified users
- Notfied users about IPEX being optional
- Notified users about 'xccl' backend, fixed the doc example. Varuni
  helped with testing.
- Removed mention of the frameworks-optimized module. Will bring it
  back, once it is thoroughly tested
- Added a Major Changes section at the top of the page to summarize
  these changes

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
