### PR TITLE
Revise JupyterLab login instructions in documentation

### DIFF
--- a/docs/aurora/data-science/jupyter.md
+++ b/docs/aurora/data-science/jupyter.md
@@ -16,11 +16,11 @@ Please note that you only need a terminal (to SSH into Aurora) and a browser on 
    ```bash
    ssh <your-username>@aurora.alcf.anl.gov
    ```
-   Make a note of the specific login node ID that you landed on. Run `hostname -f`, which may return something like:
+   Make a note of the specific login node ID that you landed on. Run `hostname`, which may return something like:
    ```output
-   aurora-uan-0011.hostmgmt.cm.aurora.alcf.anl.gov
+   aurora-uan-0011
    ```
-
+   You can use `aurora-uan-0011.aurora.alcf.anl.gov` as the hostname to connect to the same login node.
 2. **Create a Virtual Environment**:
    If you already have a Python environment, you can skip this step.
    ```bash
@@ -70,7 +70,7 @@ Please note that you only need a terminal (to SSH into Aurora) and a browser on 
    ```bash
    ssh -L 9999:127.0.0.1:9999 <your-username>@<login_node_hostname>
    ```
-   where `<login_node_hostname>` is the specific login node address noted in step 1.1.
+   where `<login_node_hostname>` is the specific login node address noted in step 1.
    - Replace `9999` with another port if it is unavailable.
 
 4. **Access JupyterLab**:


### PR DESCRIPTION
Updated instructions for logging into Aurora and accessing JupyterLab. Changed hostname command output and clarified login node hostname usage since the hostname returned by `hostname -f` is not accessible.

## Description
<!-- Describe your changes in detail -->

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
