### PR TITLE
Fix pbs-tui command and add installation instructions

### DIFF
--- a/docs/running-jobs/index.md
+++ b/docs/running-jobs/index.md
@@ -35,9 +35,9 @@ compute resources for all systems at ALCF.
             uvx pbs-tui
             ```
 
-          [^uv]: To install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 
+[^uv]: To install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 ## Introduction
 
 At a high level, getting computational tasks run on an HPC system is a two-step process:


### PR DESCRIPTION
## Copilot Summary

This pull request updates the documentation for running jobs at ALCF to clarify usage and installation instructions for the `pbs-tui` tool. The most important changes are:

**Documentation improvements:**

* Updated the `pbs-tui` usage instructions to use `uvx pbs-tui` instead of the previous `uv run --with pbs-tui pbs-tui` command, simplifying how users launch the tool.
* Added a footnote with installation instructions for `uv`, helping users set up the required environment more easily.


## Description

Updated command for pbs-tui usage and added installation note.	