### PR TITLE
Correct markdown links in node performance overview

### DIFF
--- a/docs/aurora/node-performance-overview/node-performance-overview.md
+++ b/docs/aurora/node-performance-overview/node-performance-overview.md
@@ -95,4 +95,4 @@ See the source code for this test: [`gemm.cpp`](./src/gemm.cpp)
 | Single-precision FFT C2C 1D |  3 TFlop/s | 34 TFlop/s |    10.8 |
 | Single-precision FFT C2C 2D |  3 TFlop/s | 35 TFlop/s |    10.4 |
 
-See the source code for this test: [`fft2c.cpp`](./src/fft2c.cpp)
+See the source code for this test: [`fftc2c.cpp`](./src/fftc2c.cpp)


### PR DESCRIPTION
## Description

Fixed markdown links for source code references in the performance overview documentation.

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [x] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
