### PR TITLE
Adding note that the `--intel` flag isn't needed with icpx or icx

### DIFF
--- a/docs/aurora/compiling-and-linking/aurora-programming-models.md
+++ b/docs/aurora/compiling-and-linking/aurora-programming-models.md
@@ -24,7 +24,7 @@ A summary of available GPU programming models and relevant compiler flags is sho
 | OpenMP | -fiopenmp -fopenmp-targets=spir64 | -fiopenmp -fopenmp-targets=spir64_gen -Xopenmp-target-backend=spir64_gen "-device pvc" |
 | SYCL | --intel -fsycl -fsycl-targets=spir64 | --intel -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device pvc" |
 
-!!! note
+!!! tip
      `--intel` is only needed if the base compiler isn't `icpx` or `icx`
 
 For some build systems (e.g., `cmake`), it may be necessary to use the backslash character to escape the double quotes when specifying the device in AoT builds.


### PR DESCRIPTION
From a discussion with an Intel engineer, we found out that `--intel` is a no-op when running via icx/icpx.  If we use icx/icpx, `--intel` is passed automatically. Thus I wanted to add a comment about it so people don't think they need to add it in.


## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
