### PR TITLE
Document access token retrieval and validity

### DIFF
--- a/docs/services/inference-endpoints.md
+++ b/docs/services/inference-endpoints.md
@@ -66,6 +66,11 @@ This will generate and store access and refresh tokens in your home directory. T
 python inference_auth_token.py get_time_until_token_expiration --units seconds
 ```
 
+To print your token to the command line, this command can be used:
+```bash
+python inference_auth_token.py get_access_token
+```
+
 !!! warning "Token Validity"
     - Access tokens are valid for 48 hours. The `get_access_token` command will automatically refresh your token if it has expired.
     - An internal policy requires re-authentication every 30 days. If you encounter permission errors, logout from Globus at [app.globus.org/logout](https://app.globus.org/logout) and re-run `python inference_auth_token.py authenticate --force`.


### PR DESCRIPTION
Added command to print access token and updated token validity information.

## Description
<!-- Describe your changes in detail -->

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
