### PR TITLE
removed reference to prod-large queue

### DIFF
--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -28,7 +28,7 @@ There are four production queues you can target in your qsub (`-q <queue name>`)
 
 !!! warning
 
-    You cannot submit to these queues directly; you can only submit to the routing queue `prod` or `prod-large`.
+    You cannot submit to these queues directly; you can only submit to the routing queue `prod`.
 
 !!! note
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
