### PR TITLE
Update frameworks/DeepSpeed version in documentation

### DIFF
--- a/docs/aurora/data-science/frameworks/deepspeed.md
+++ b/docs/aurora/data-science/frameworks/deepspeed.md
@@ -5,13 +5,13 @@ The base `frameworks` environment on Aurora now comes with Microsoft's [DeepSpee
 ```bash
 module load frameworks
 ```
-The following output is from the `frameworks/2025.2.0` module:
+The following output is from the `frameworks/2025.3.1` module:
 
 ```python
 import deepspeed
 
 deepspeed.__version__
-'0.17.5'
+'0.18.5'
 ```
 
 <!---


### PR DESCRIPTION
Updated the version of the DeepSpeed module from 0.17.5 to 0.18.5 and update the version of the frameworks module to 2025.3.1

## Description
<!-- Describe your changes in detail -->

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
