### PR TITLE
Update Dragon docs for Aurora

### DIFF
--- a/docs/aurora/workflows/dragon.md
+++ b/docs/aurora/workflows/dragon.md
@@ -22,8 +22,9 @@ dragon-config add --ofi-runtime-lib=/opt/cray/libfabric/1.22.0/lib64
 
 The last installation step that calls `dragon-config` is necessary to enable `dragon` to use high-speed RDMA transfers across Aurora's Slingshot network.  Skipping this step will result in `dragon` using slower TCP transfers for cross node communication and data transfer.
 
-!!! info "GPU Device Hierarchy"
-    * Dragon is able to support both composite and flat settings for the GPU device hierarchy (set with `ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE` and `ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE`, respectively). In composite mode, 6 GPU devices are exposed, each with 2 sub-devices (tiles). In flat mode, 12 GPU devices are exposed (tile-as-device). Most applications on Aurora benefit from the flat mode, which is set by default when loading the `frameworks` module. 
+!!! info "Managing GPU Devices on Aurora"
+   * Dragon uses `xpu-smi` to discover devices Intel GPU devices, however this tool is not available by default on Aurora. To make the best use of Dragon's internal GPU discovery utilities, add `module load xpu-smi` to your job scripts.
+   * Dragon is able to support both composite and flat settings for the GPU device hierarchy (set with `ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE` and `ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE`, respectively). In composite mode, 6 GPU devices are exposed, each with 2 sub-devices (tiles). In flat mode, 12 GPU devices are exposed (tile-as-device). Most applications on Aurora benefit from the flat mode, which is set by default when loading the `frameworks` module. 
 
 
 


### PR DESCRIPTION
Add suggestion to load xpu-smi module when running Dragon on Aurora to make best use of their internal GPU discovery utilities. 

## Description
Simple one-line change to Dragon documentation on Aurora.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
