### PR TITLE
Changing Getting Started Link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,7 +152,7 @@ plugins:
 nav:
   # - ALCF User Guides:
   #   - index.md
-  - Getting Started: https://www.alcf.anl.gov/support-center/get-started
+  - Getting Started: https://www.alcf.anl.gov/managing-your-award
   - Contribute to User Guides: support/docs-issues.md
 
   - User Support:


### PR DESCRIPTION
## Description
I've changed the Getting Started link in the ToC to take the user to the managing your award guide. This guide is more comprehensive & covers all award types, not just DD. We are going to overhaul the content in the old link, so it won't be as relevant to the user guides anymore. 

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
