### PR TITLE
Update Intel_sanitizer.md to include workaround for sanitizer issue

### DIFF
--- a/docs/aurora/debugging/Intel_sanitizer.md
+++ b/docs/aurora/debugging/Intel_sanitizer.md
@@ -118,6 +118,17 @@ or
 export DisableDeepBind=1
 ```
 
+### SEGV on multi-node runs with ASAN on the host
+
+When a code is compiled with "-Xarch_host -fsanitize=address" to turn on address sanitizer on the device, there may be a SEGV as below:
+
+```console
+> mpicxx -Xarch_host -fsanitize=address -fsycl sycl.cpp
+> mpirun -n 2 -ppn 1 ./a.out
+==111900==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000898ce (pc 0x0000000898ce bp 0x000000000000 sp 0x7ffc1a1e1f38 T0)
+```
+
+This is due to a conflict of libfabric's memory monitor memhook (the default) and asan both intercepting mmap in incompatible ways, resulting in ASAN segfaulting. A workaround for this is to change the Libfabric memory monitor and set: `export FI_MR_CACHE_MONITOR=userfaultfd`. See more details here: https://github.com/argonne-lcf/AuroraBugTracking/issues/141 
 
 ## References  
 [Intel Sanitizer documentation](https://www.intel.com/content/www/us/en/developer/articles/technical/find-bugs-quickly-using-sanitizers-with-oneapi-compiler.html)

--- a/docs/aurora/debugging/Intel_sanitizer.md
+++ b/docs/aurora/debugging/Intel_sanitizer.md
@@ -123,7 +123,7 @@ export DisableDeepBind=1
 When a code is compiled with "-Xarch_host -fsanitize=address" to turn on address sanitizer on the device, there may be a SEGV as below:
 
 ```console
-> mpicxx -Xarch_host -fsanitize=address -fsycl sycl.cpp
+> mpicxx -Xarch_host -fsanitize=address -fsycl -g sycl.cpp
 > mpirun -n 2 -ppn 1 ./a.out
 ==111900==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000898ce (pc 0x0000000898ce bp 0x000000000000 sp 0x7ffc1a1e1f38 T0)
 ```


### PR DESCRIPTION
## Description
This adds a workaround for a sanitizer issue as described here: https://github.com/argonne-lcf/AuroraBugTracking/issues/141#issuecomment-4599112376

## Related Issue(s)
https://github.com/argonne-lcf/AuroraBugTracking/issues/141

## Type of Change

- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
