### PR TITLE
Correct number of SambaRacks in system overview

### DIFF
--- a/docs/ai-testbed/sn40l_inference/index.md
+++ b/docs/ai-testbed/sn40l_inference/index.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-SambaStack is a purpose-built hardware and software platform optimized for AI inference, powered by SambaNova’s advanced Reconfigurable Dataflow Unit (RDU) processors. At the core of this infrastructure is a SambaNova SN40L cluster, composed of four SambaRacks—- each housing 16 SN40L RDU systems. This dedicated setup delivers high-throughput, low-latency performance for machine learning workloads. Models running on the cluster are exposed through OpenAI-compatible API endpoints, with each endpoint capable of hosting multiple independently accessible models.
+SambaStack is a purpose-built hardware and software platform optimized for AI inference, powered by SambaNova’s advanced Reconfigurable Dataflow Unit (RDU) processors. At the core of this infrastructure is a SambaNova SN40L cluster, composed of six SambaRacks—- each housing 16 SN40L RDU systems. This dedicated setup delivers high-throughput, low-latency performance for machine learning workloads. Models running on the cluster are exposed through OpenAI-compatible API endpoints, with each endpoint capable of hosting multiple independently accessible models.
 
 
 Below are some of the links to SambaNova documentation:


### PR DESCRIPTION
Updated the number of SambaRacks from four to six in the system overview.

## Description
<!-- Describe your changes in detail -->

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
