### PR TITLE
adjusting capacity queue on Aurora to current 512 nodes setting.

### DIFF
--- a/docs/aurora/running-jobs-aurora.md
+++ b/docs/aurora/running-jobs-aurora.md
@@ -10,7 +10,7 @@ There are four production queues you can target in your qsub (`-q <queue name>`)
 | debug          | 1        | 2          | 5 min    | 1 hr             | 64 nodes (non-exclusive);  <br/> Max 1 job running/accruing/queued **per-user**                 |
 | debug-scaling  | 2        | 256        | 5 min    | 1 hr             | Max 1 job running/accruing/queued **per-user**                                                  |
 | prod           | 256      | 10,624[^1] | 5 min    | 24 hrs           | Routing queue for small, medium, and large queues; <br/> **See table below for min/max limits** |                                                                       |
-| capacity       | 1        | 16         | 5 min    | 7 days (168 hrs) | Max of 128 nodes across all jobs. Max 5 jobs queued or running, 2 jobs running per user.  **Starting 6/26/26 this queue will have a max of 512 nodes across all jobs.**      |
+| capacity       | 1        | 16         | 5 min    | 7 days (168 hrs) | Max of 512 nodes across all jobs. Max 5 jobs queued or running, 2 jobs running per user.      |
 | visualization  | 1        | 32         | 5 min    | 8 hrs            | ***By request only; non-exclusive nodes***                                                      |
 
 `prod` is the routing queue and routes your job to one of the following execution queues:


### PR DESCRIPTION
## Description
Updating running jobs docs for new simultaneous node limit for the capacity queue on aurora


## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x ] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
