### PR TITLE
inference-endpoints: add section on configuring coding agents

### DIFF
--- a/docs/services/inference-endpoints.md
+++ b/docs/services/inference-endpoints.md
@@ -28,6 +28,62 @@ In the model selection dropdown, you can see the status of each model:
 !!! note "For Advanced UI Features"
     For a full guide on advanced features like RAG (Retrieval-Augmented Generation), function calling, and more, please refer to the official [Open WebUI documentation](https://docs.openwebui.com/).
 
+### Coding Agents
+
+If your coding agent supports *external endpoint providers*, you can configure your agent to utilize the ALCF Inference Service endpoint as its backend.
+
+| Cluster | Endpoint URL |
+| --- | --- |
+| Sophia | `https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1` |
+| Metis | `https://inference-api.alcf.anl.gov/resource_server/metis/api/v1` |
+
+The model can be specified by it's fully qualfied name (see [Available Models](#available-models)).
+
+!!! warning "Responses API Support"
+    Streaming support is currently **disabled** for the OpenAI Responses API, meaning agents which rely on the Responses API as its default wire protocol will fail to send requests to the Inference Service. Configure your agent to utilize the OpenAI Chat Completion API instead for compatibility.
+
+#### Codex
+
+OpenAI's Codex is a popular coding agent that can be configured to use the ALCF Inference Service.
+
+##### 1. Installation
+
+!!! note "Codex Version Requirement"
+    Codex removed support for the Chat Completion API in `0.95`. Use `0.94` or lower for the Inference Service endpoints to be supported.
+
+Install [Codex `0.94`](https://github.com/openai/codex/releases/tag/rust-v0.94.0).
+
+If you use Nix, you can use this command to pull the correct version into an ephemeral shell: `nix-shell -p codex -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/cc4bd5f859cdf01153d999995c20c9a457045bd6.tar.gz`.
+
+##### 2. Configuration
+
+In your `~/.codex/config.toml`, add these configuration values.
+
+```toml
+model = "<your model here>"
+model_provider = "inference-service"
+
+[model_providers.inference-service]
+name = "ALCF Inference Service"
+base_url = "<your endpoint url here>"
+env_key = "ALCF_AI_TOKEN"
+wire_api = "chat" # required to use Chat Completion API
+```
+
+`openai/gpt-oss-120b` is provided by both Sophia and Metis and is a good default model choice for Codex.
+
+##### 3. Usage
+
+Before running Codex, a valid token needs to be stored in the `ALCF_AI_TOKEN` environment variable. You can either set a key manually (see [API Access](#api-access)) or utilize `alcf-ai`.
+
+```sh
+uvx alcf-ai auth login # follow interactive instructions to login
+
+export ALCF_AI_TOKEN="$(uvx alcf-ai auth get-access-token)" # pull a token and store
+
+codex # now, you can finally run Codex and begin vibecoding
+```
+
 ### API Access
 
 For programmatic access, you can use the API endpoints directly.

--- a/docs/services/inference-endpoints.md
+++ b/docs/services/inference-endpoints.md
@@ -30,32 +30,101 @@ In the model selection dropdown, you can see the status of each model:
 
 ### Coding Agents
 
-If your coding agent supports *external endpoint providers*, you can configure your agent to utilize the ALCF Inference Service endpoint as its backend.
+If your coding agent supports *external endpoint providers*, you can configure your agent to utilize the ALCF Inference Service endpoints as a backend.
 
-| Cluster | Endpoint URL |
-| --- | --- |
-| Sophia | `https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1` |
-| Metis | `https://inference-api.alcf.anl.gov/resource_server/metis/api/v1` |
+#### OpenCode (recommended)
 
-The model can be specified by it's fully qualfied name (see [Available Models](#available-models)).
+[OpenCode](https://opencode.ai/) is an open-source coding agent that is well-supported by the ALCF Inference Service.
 
-!!! warning "Responses API Support"
-    Streaming support is currently **disabled** for the OpenAI Responses API, meaning agents which rely on the Responses API as its default wire protocol will fail to send requests to the Inference Service. Configure your agent to utilize the OpenAI Chat Completion API instead for compatibility.
+##### Installation
+
+Run their installation script:
+
+```sh
+curl -fsSL https://opencode.ai/install | bash
+source ~/.bashrc
+```
+
+Alternatively, you can also install via your system package manager (i.e. `brew`, `apt`, etc.).
+
+##### Automatic Configuration w/ alcf-ai
+
+You can quick-configure `opencode` to use the ALCF Inference Service endpoints with `alcf-ai`. This also handles authentication and pulling an API key from the service.
+
+```sh
+curl -LsSf https://astral.sh/uv/install.sh | sh # install uv (if needed)
+uvx alcf-ai agent configure opencode
+
+opencode
+```
+
+!!! tip "Refreshing API Keys"
+    `alcf-ai agent configure <agent>` is *idempotent*, meaning you can re-run this command to embed a fresh token into your agent config!
+
+##### Manual Configuration
+
+After installing `opencode`, place the following in your `~/.config/opencode/opencode.jsonc`.
+
+```json
+{
+    ...
+    "provider": {
+        "alcf-inference-service-sophia": {
+            "name": "ALCF Inference Service (Sophia)",
+            "npm": "@ai-sdk/openai-compatible",
+            "options": {
+                "baseURL": "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
+                "apiKey": "{env:ALCF_AI_TOKEN}"
+            },
+            "models": {
+                "openai/gpt-oss-120b": {
+                    "name": "openai/gpt-oss-120b",
+                    "timeout": false,
+                    "limit": {
+                        "context": 65536,
+                        "output": 0
+                    }
+                }
+            }
+        }
+    }
+    ...
+}
+```
+
+Before running `opencode`, a valid token needs to be stored in the `ALCF_AI_TOKEN` environment variable. You can either set a key manually (see [API Access](#api-access)) or utilize `alcf-ai`.
+
+```sh
+uvx alcf-ai auth login # follow interactive instructions to login
+export ALCF_AI_TOKEN="$(uvx alcf-ai auth get-access-token)" # pull a token and store
+
+opencode
+```
 
 #### Codex
 
-OpenAI's Codex is a popular coding agent that can be configured to use the ALCF Inference Service.
+OpenAI's [Codex](https://openai.com/codex) is a popular coding agent popularized during the rise of ChatGPT. Codex also supports external model providers and can be configured to use the ALCF Inference Service.
 
-##### 1. Installation
+##### Installation
 
-!!! note "Codex Version Requirement"
-    Codex removed support for the Chat Completion API in `0.95`. Use `0.94` or lower for the Inference Service endpoints to be supported.
+!!! warning "Codex Version Requirement"
+    Codex removed support for the Chat Completions API in `0.95`. Use `0.94` or lower for the ALCF Inference Service endpoints to be fully supported.
 
 Install [Codex `0.94`](https://github.com/openai/codex/releases/tag/rust-v0.94.0).
 
 If you use Nix, you can use this command to pull the correct version into an ephemeral shell: `nix-shell -p codex -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/cc4bd5f859cdf01153d999995c20c9a457045bd6.tar.gz`.
 
-##### 2. Configuration
+##### Automatic Configuration w/ alcf-ai
+
+`alcf-ai` also supports configuring Codex:
+
+```sh
+uvx alcf-ai agent configure codex
+
+codex
+```
+
+##### Manual Configuration
 
 In your `~/.codex/config.toml`, add these configuration values.
 
@@ -67,22 +136,33 @@ model_provider = "inference-service"
 name = "ALCF Inference Service"
 base_url = "<your endpoint url here>"
 env_key = "ALCF_AI_TOKEN"
-wire_api = "chat" # required to use Chat Completion API
+wire_api = "chat" # required to use Chat Completions API
 ```
 
-`openai/gpt-oss-120b` is provided by both Sophia and Metis and is a good default model choice for Codex.
+You will need to set the `ALCF_AI_TOKEN` environment variable to your ALCF AI token before running `codex`.
 
-##### 3. Usage
+!!! note "Suggested Models"
+    `openai/gpt-oss-120b` is provided by both Sophia and Metis and is a good default model choice for Codex. Models which perform tool calls must conform to the OpenAI Harmony format for their outputs to be accepted by the agent.
 
-Before running Codex, a valid token needs to be stored in the `ALCF_AI_TOKEN` environment variable. You can either set a key manually (see [API Access](#api-access)) or utilize `alcf-ai`.
+#### Other 3rd-Party Agents
 
-```sh
-uvx alcf-ai auth login # follow interactive instructions to login
+Other OpenAI-compatible agents can also be configured to use the service, albeit with varying degrees of support. After familiarizing yourself with your agent's configuration format, see [Available Clusters](#available-clusters) for integration choices. The model can be specified by its fully qualfied name (see [Available Models](#available-models)).
 
-export ALCF_AI_TOKEN="$(uvx alcf-ai auth get-access-token)" # pull a token and store
+##### Shims/Proxies
 
-codex # now, you can finally run Codex and begin vibecoding
-```
+Some AI agents need to have their inference requests translated and sanitized prior to calling the ALCF Inference Service endpoints for correct behavior. Several community-developed shims and resources are available to aid the integration of these agents with the service:
+
+1. [alcf-proxy](https://alcf-proxy.readthedocs.io/en/latest) - [Hongwei Jin](https://www.anl.gov/profile/hongwei-jin)
+2. [DIY w/ llm-rosetta](https://samf.sh/posts/2026/06/27) - [Sam Foreman](https://www.alcf.anl.gov/about/people/sam-foreman)
+
+!!! warning "Responses API Streaming Support"
+    Streaming support is currently **disabled** for the OpenAI Responses API on *non-Direct API endpoints*. This means agents that rely on the Responses API as their default wire protocol will fail to send requests to clusters like Sophia. Either configure your agent to utilize the OpenAI Chat Completions API or switch clusters for compatibility.
+
+!!! warning "Metis Tool Calling"
+    There is a known issue related to SambaNova's sanitization of tool calls, leading to strange error responses like this when processing requests.
+    ```json
+    {\"error\":\"Model started a function call but did not complete it.\",\"error_code\":null,\"error_model_output\":\"\\u003c|channel|\\u003eanalysis\\u003c|message|\\u003eWe needto adjust imports and usage in main.rs.\\n\\nSearch for clear_lines usage. Already seen at line 327. Need to modify that block.\\n\\nOpen around lines 320-340.\\u003c|end|\\u003e\\u003c|start|\\u003eassistant\\u003c|channel|\\u003ecommentary to=functions.read\\u003c|message|\\u003e{\\\"filePath\\\":\\\"/Users/ewong/Documents/alcf/inference-service/vibecoding/rust_vibecoding/src/main.rs\\\",\\\"offset\\\":320,\\\"limit\\\":80}\",\"error_param\":null,\"error_type\":\"Invalid function calling output.\"}
+    ```
 
 ### API Access
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds documentation on hooking up agents to the ALCF Inference Service.

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

Dependent on changes in https://github.com/argonne-lcf/FIRST/pull/266 before Codex will properly function.

These are required for `alcf-ai` usage and Responses API support as displayed in the docs.

- https://github.com/argonne-lcf/FIRST/pull/269
- https://github.com/argonne-lcf/FIRST/pull/276

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
