### PR TITLE
adding curl -O alternative

### DIFF
--- a/docs/services/iri-api.md
+++ b/docs/services/iri-api.md
@@ -23,6 +23,8 @@ Download our auth script from [this repository](https://github.com/argonne-lcf/a
 wget https://raw.githubusercontent.com/argonne-lcf/alcf-facility-api-token/refs/heads/main/alcf_facility_api_globus_token.py
 ```
 
+If `wget` does not work, please try `curl -O` instead.
+
 ### 2. Authenticate
 
 Generate the authentication flow URL with the command below. Copy-paste the URL to your browser, authenticate with your ALCF credentials, and copy-paste the resulting authorization code in your terminal.

--- a/docs/services/iri-api.md
+++ b/docs/services/iri-api.md
@@ -23,7 +23,7 @@ Download our auth script from [this repository](https://github.com/argonne-lcf/a
 wget https://raw.githubusercontent.com/argonne-lcf/alcf-facility-api-token/refs/heads/main/alcf_facility_api_globus_token.py
 ```
 
-If `wget` does not work, please try `curl -O` instead.
+If `wget` is unavailable on your system, try `curl -O` instead.
 
 ### 2. Authenticate
 


### PR DESCRIPTION
## Description
Adding an alternative to `wget` for downloading the auth script for the IRI API.

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
