### PR TITLE
docs(running-jobs): clarify job array limits in the prod routing queue

### DIFF
--- a/docs/running-jobs/example-job-scripts.md
+++ b/docs/running-jobs/example-job-scripts.md
@@ -394,8 +394,32 @@ qdel 1991684[]
 
 ### Limits on job arrays
 
-The number of subjobs in a job array is limited by the number of jobs that can be submitted to the queue.
+The number of subjobs that a job array can have **in the queued or running state at one time** is limited by the number of jobs that can be simultaneously queued/running in the destination queue.
 
-On Polaris, for the debug queue, that is 1, for preemptable, that is 20, and for prod that is 10.
+On Polaris, that concurrent limit is:
 
-The limit for prod on Polaris is 10 because 10 is the maximum number of jobs that can be routed by prod to one of the execution queues (small, medium, or large). One note, PBS will allow job array submissions of up to 100 subjobs in prod, however, these job arrays will not run because they will not route to an execution queue. This is a known issue on Polaris.
+| Queue | Max concurrent (queued + running) jobs |
+| --- | --- |
+| `debug` | 1 |
+| `preemptable` | 20 |
+| `prod` | 10 |
+
+The limit for `prod` on Polaris is 10 because 10 is the maximum number of jobs that can be routed by `prod` to one of the execution queues (`small`, `medium`, or `large`) at once.
+
+!!! warning "A job array wider than the queue limit will never run in `prod`"
+
+    PBS will *accept* a job array submission to `prod` with up to 100 subjobs, but if more subjobs become eligible than the routing limit allows, the excess subjobs **cannot route to an execution queue and will sit forever without running** (they accrue eligible time but are never placed). This is a known issue on Polaris. It is easy to hit accidentally with a parameter sweep, because by default *every* subjob in an array becomes eligible the moment the array is submitted.
+
+    **To use an array in `prod`, throttle the number of concurrently eligible subjobs with `%<num_concurrent>` so it never exceeds the queue limit.** For example, an array of 100 subjobs that only ever has 10 eligible at a time is compatible with the `prod` limit of 10:
+
+    ```bash
+    #PBS -J 0-99%10
+    ```
+
+    You can also apply the throttle to an already-submitted array without resubmitting:
+
+    ```bash
+    qalter -J 0-99%10 <job_array_id>[]
+    ```
+
+    If you cannot express your work within the concurrent limit (for example you want many subjobs running at once), submit the array to `preemptable` (limit 20) instead of `prod`, or drive the tasks with a [workflow management tool](../polaris/workflows/balsam.md) such as Balsam rather than a job array.

--- a/docs/running-jobs/known-issues.md
+++ b/docs/running-jobs/known-issues.md
@@ -73,6 +73,28 @@ This means that the resources you requested for your job are not yet available (
 The ```Not Running: Job is requesting an exclusive node and node is in use``` comment means you have requested a specific node, 
 instead of allowing PBS to select the first available node(s) for your job, and the specific compute node you requested in still in use or unavailable. 
 
+## Job Array Submitted to `prod` Never Runs
+
+If you submit a [job array](example-job-scripts.md#job-array-example) to the Polaris (or Aurora) `prod` routing queue and it sits indefinitely without ever running &mdash; accruing eligible time but never being placed &mdash; the most likely cause is that the array has **more concurrently eligible subjobs than the routing queue allows**.
+
+`prod` is a routing queue that can route at most a fixed number of jobs to the execution queues (`small`, `medium`, `large`) at one time (10 on Polaris). By default, *every* subjob in an array becomes eligible as soon as the array is submitted, so an array wider than that limit cannot fully route, and the excess subjobs never run. PBS will accept the submission without an error, which makes this easy to hit accidentally with a parameter sweep.
+
+To diagnose, look at the array and its subjobs:
+
+```shell
+qstat -t <job_array_id>[]
+qstat -was1 <job_array_id>[]
+```
+
+To fix, throttle the number of concurrently eligible subjobs with `%<num_concurrent>` so it never exceeds the queue limit (e.g. `%10` for Polaris `prod`). You can do this at submit time or on an already-submitted array:
+
+```shell
+#PBS -J 0-99%10                    # at submission
+qalter -J 0-99%10 <job_array_id>[] # on an existing array
+```
+
+If you need more subjobs eligible at once than `prod` permits, use the `preemptable` queue (higher limit) or a [workflow management tool](../polaris/workflows/balsam.md) such as Balsam instead. See [Limits on job arrays](example-job-scripts.md#limits-on-job-arrays) for details.
+
 ## "Job to be deleted at request of Scheduler"
 
 If you are running in the ```preemptable``` queue on Polaris and receive an email informing you that your has been deleted by at the request of the scheduler, 


### PR DESCRIPTION
## Summary

Clarifies the documentation around **job array limits in the `prod` routing queue**, where arrays wider than the routing limit are silently accepted by PBS but never run. This is a known Polaris issue that users hit accidentally with parameter sweeps, because by default every subjob becomes eligible the moment the array is submitted.

The behavior was already noted at the bottom of `example-job-scripts.md`, but it (1) was not surfaced as a warning, (2) never connected the limit to the `%<num_concurrent>` fix that resolves it, and (3) was absent from the PBS troubleshooting page — the page users actually consult when a job won't run.

## Changes

- **`docs/running-jobs/example-job-scripts.md`** — reworked the "Limits on job arrays" section: turned the buried note into a `!!! warning` admonition, added a queue-limit table (debug 1 / preemptable 20 / prod 10 on Polaris), and connected the limit to the fix — throttling concurrently-eligible subjobs with `%<num_concurrent>` (at submit time or via `qalter`), with `preemptable` / Balsam as alternatives when more concurrency is needed.
- **`docs/running-jobs/known-issues.md`** — added a dedicated **"Job Array Submitted to `prod` Never Runs"** troubleshooting entry with `qstat` diagnostics and the fix, cross-linked to the section above, so the failure mode is discoverable from the troubleshooting page.

## Notes / open item for maintainers

- The Aurora `prod` queue is also a routing queue (per `known-issues.md`), so I referenced it as "(or Aurora)" using the general routing-queue mechanism, but I did **not** assert a specific Aurora numeric array limit since I could not verify it. If Aurora has a known concrete limit, it would be worth stating explicitly.
- The `%<num_concurrent>` throttle is presented as the primary fix on the assumption the routing cap counts concurrently-eligible subjobs. If a site config detail makes `%N` insufficient in `prod`, please flag it and I'll adjust to steer users to `preemptable`/Balsam instead.
