### PR TITLE
Remove Cray MPICH RMA inter-node deadlock from Polaris "Known Issues"

### DIFF
--- a/docs/polaris/known-issues.md
+++ b/docs/polaris/known-issues.md
@@ -48,7 +48,3 @@ Alternatively, it can be set with the `mpiexec` command, e.g.
 ```bash
 mpiexec --env TMPDIR=/tmp -n 1 --ppn 1 ...
 ```
-
-## Inter-node MPI RMA operations 
-
-There is a known bug in Cray MPICH concerning inter-node MPI RMA operations (e.g. `MPI_Get()`, `MPI_Put()`, `MPI_Win_flush()`), whereby the application can hang trying to read a counter from the Cassini NIC. It was noticed sometime after the August 2025 system upgrade. HPE is aware and working on a fix. The only known workaround is to use a fresh OpenMPI build, but that approach will likely face large performance costs.


### PR DESCRIPTION
Pushing the edits prematurely, in advance of the sync to Polaris during a PM. 