### PR TITLE
Formatting fixes; enable pymdownx.emoji extension

### DIFF
--- a/docs/account-project-management/accounts-and-access/accounts-and-access-faqs.md
+++ b/docs/account-project-management/accounts-and-access/accounts-and-access-faqs.md
@@ -16,6 +16,7 @@ Please see [Allocations on ALCF Systems](../allocation-management/index.md)
 To renew or request an extension or request additional hours for your existing compute allocations, please fill out the [Allocation Request Form](https://my.alcf.anl.gov/accounts/#/allocationRequests). 
 
 For storage-allocation renewals/extensions/quota increases, email [support@alcf.anl.gov](mailto:support@alcf.anl.gov) with answers to the following:
+
 - What have you accomplished with your original allocation?
   - Please include a brief description of any publications or major presentations that were (or will be) generated in full or in part because of this allocation.
 - What will you do with the extra time?

--- a/docs/account-project-management/accounts-and-access/index.md
+++ b/docs/account-project-management/accounts-and-access/index.md
@@ -9,11 +9,12 @@ If you want to learn how to get started, visit the [Get Started Guide](https://w
 ## Who Can Get an Account
 
 Those who are interested in having an account on an ALCF resource must first request an allocation and provide a detailed description of the work, including computational requirements and coding capabilities for the applicable ALCF resources.
+
 Alternatively, one may be part of a project team that already has an active allocation. Once an allocation has been granted, new users should complete an account request. A project’s Principal Investigator (PI) must sponsor these accounts—if the PI is the user, an ALCF staff member must serve as sponsor. Sponsors are asked annually to evaluate the accounts they have sponsored to determine whether or not these accounts should be kept active.
 
 ## Account Abilities
 
-A user with an active account can log in to the ALCF login servers (e.g., polaris.alcf.anl.gov). This account will have some home directory space, where file transfer can occur from that space via the login nodes, and where development activities, such as editing and compiling, can also occur.
+A user with an active account can log in to the ALCF login node via SSH (e.g. `ssh polaris.alcf.anl.gov`). This account will have some home directory space, where file transfer can occur from that space via the login nodes, and where development activities, such as editing and compiling, can also occur.
 
 ## Account States
 

--- a/docs/account-project-management/allocation-management/allocation-management.md
+++ b/docs/account-project-management/allocation-management/allocation-management.md
@@ -154,6 +154,7 @@ sbank-list-allocations -r polaris -p <projectname> -f "+subname users_list"
 
 ##### Q3: Can a suballocation have a negative balance?
 **A:** Yes. Suballocations can go negative for different reasons. 
+
  - When the suballocation has a positive balance at the time jobs are **queued** but once jobs finish running the charges exceed the balance that was available when they were queued.
  - If the **allocation** has a negative balance (regardless of whether the suballocation has a positive balance or not, as long as the allocation is still active), jobs will be routed to backfill queues.
 

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-detail-projects.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-detail-projects.md
@@ -45,6 +45,7 @@ filter on name or id, DO NOT MIX, enter 'all' to get all, wild cards '*' is allo
 - OPER1 is 'lt' for single date entry, OPER1 and OPER2 are 'ge' and 'lt', respectively, for range date entry. 
 
 **Date Parsing Precedence:** 
+
   - YEAR then MONTH then DAY, i.e., 121101 is parsed as YYMMDD, hence Nov. 1, 2012
 
 #### **-H, --human-readable**

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-detail-users.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-detail-users.md
@@ -52,6 +52,7 @@ Filter on name or ID. DO NOT MIX. Enter 'all' to get all. Wildcards '*' are allo
 #### -E END, --end=END
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following:
+
 - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`.
 
 **Operator Defaults:**
@@ -73,6 +74,7 @@ Get inactive allocations.
 #### -S START, --start=START
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following:
+
 - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`.
 
 **Operator Defaults:**

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-examples.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-examples.md
@@ -204,6 +204,7 @@ Totals:
 List of transactions that were at or after 2016-02-29 for ProjectX add fields: job_duration, nodes_used, and hosts
 
 **Note**: 
+
 - job_duration, nodes_used, and hosts are shortened, but they are still uniquely identified
 - host has the left justified width of 20, specified as "h:-20"
 

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-list-allocations.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-list-allocations.md
@@ -49,6 +49,7 @@ Filter on name or ID. DO NOT MIX. Enter `all` to get all. Wildcards `*` are allo
 
 #### -E END, --end=END
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators OPER1 and OPER2 can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -70,6 +71,7 @@ Only inactive allocations.
 
 #### -S START, --start=START
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators OPER1 and OPER2 can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -94,6 +96,7 @@ Filter on Clusterbank reference ID.
 
 #### --created=CREATED_TIMESTAMP
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators OPER1 and OPER2 can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -118,6 +121,7 @@ Only show list info that have charges regardless of project/user relationship.
 
 #### --last-updated=LAST_UPDATED_TIMESTAMP
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators OPER1 and OPER2 can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-list-jobs.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-list-jobs.md
@@ -57,6 +57,7 @@ Filter on name or ID. DO NOT MIX. Enter 'all' to get all. Wildcards '*' are allo
 #### -E END, --end=END
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -74,6 +75,7 @@ Abbreviate numbers and use unit suffixes: K (thousands), M (millions), G (billio
 #### -S START, --start=START
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -91,6 +93,7 @@ Transaction types: CHARGE, REFUND, PULLBACK, DEPOSIT, VOID.
 #### --created=CREATED_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -108,6 +111,7 @@ SILENT, MUCH_LESS, LESS, MORE, VERBOSE, DEBUG, DEBUG1, DEBUG2.
 #### --eligible=ELIGIBLE_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -125,6 +129,7 @@ Get only jobs that have not been charged.
 #### --last-updated=LAST_UPDATED_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -158,6 +163,7 @@ Do not display the totals.
 #### --queued=QUEUED_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-list-projects.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-list-projects.md
@@ -48,6 +48,7 @@ Filter on name or ID. DO NOT MIX. Enter 'all' to get all. Wildcards '*' are allo
 `"FIELD_INFO"` is `<FIELD>:<WIDTH>`. For available fields, enter `-w?` or `-w "?"`.
 
 [OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>], where the operators OPER1 and OPER2 can be one of the following:
+
 - ge, gt, le, lt, eq or >=, >, <=, <, ==.
 
 **Operator Defaults:**
@@ -69,6 +70,7 @@ Get inactive allocations.
 #### -S START, --start=START
 
 [OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>], where the operators OPER1 and OPER2 can be one of the following:
+
 - ge, gt, le, lt, eq or >=, >, <=, <, ==.
 
 **Operator Defaults:**

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-list-transactions.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-list-transactions.md
@@ -63,6 +63,7 @@ Filter on name or ID. **Do not mix.** Enter 'all' to get all. Wildcards '*' are 
 #### -E JOB_END, --end=JOB_END
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -80,6 +81,7 @@ Abbreviate numbers and use unit suffixes: K (thousands), M (millions), G (billio
 #### -S JOB_START, --start=JOB_START
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -97,6 +99,7 @@ Transaction types: CHARGE, REFUND, PULLBACK, DEPOSIT, VOID.
 #### --at=TRANSACTION_AT_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -114,6 +117,7 @@ Filter on Clusterbank reference ID.
 #### --created=JOB_CREATED_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 
@@ -151,6 +155,7 @@ Do not display the totals.
 #### --queued=JOB_QUEUED_TIMESTAMP
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`. 
   
 **Operator Defaults:** 

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-list-users.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-list-users.md
@@ -50,6 +50,7 @@ Filter on name or ID. DO NOT MIX. Enter 'all' to get all. Wildcards '*' are allo
 #### -E END, --end=END
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`.
 
 **Operator Defaults:**
@@ -71,6 +72,7 @@ Also get inactive allocations.
 #### -S START, --start=START
 
 `[OPER1]<UTC_DATE1>[...[OPER2]<UTC_DATE2>]`, where the operators `OPER1` and `OPER2` can be one of the following: 
+
   - `ge`, `gt`, `le`, `lt`, `eq` or `>=`, `>`, `<=`, `<`, `==`.
 
 **Operator Defaults:**

--- a/docs/account-project-management/allocation-management/not_in_nav/sbank-manpage.md
+++ b/docs/account-project-management/allocation-management/not_in_nav/sbank-manpage.md
@@ -23,6 +23,7 @@ HPC Accounting System Command Line Interface
 #### - list <command> [options] (DEFAULT)
 
 **DETAIL COMMANDS**
+
   * allocations [-a|-e|-f|-j|-n|-p|-r|-t|-u|-w|-E|-H|-I|-O|-S|-T|...] [<allocation_id> ... <allocation_id>] (DEFAULT) 
   * jobs [-a|-e|-f|-j|-n|-p|-r|-t|-u|-w|-E|-H|-S|-T|...] [<jobid|event_id> ... <jobid|event_id>] 
   * projects [-a|-f|-n|-p|-r|-u|-w|-E|-H|-I|-S|...] [<project name or id> ... <project name or id>] 
@@ -30,6 +31,7 @@ HPC Accounting System Command Line Interface
   * users [-a|-f|-n|-p|-r|-u|-w|-E|-H|-S|...] [<user name or id> ... <user name or id>]
 
 **LIST COMMANDS**
+
   * allocations [-a|-c|-e|-f|-j|-n|-p|-r|-t|-u|-w|-E|-H|-I|-O|-S|-T|...] (DEFAULT) 
   * jobs [-a|-e|-f|-j|-n|-p|-r|-t|-u|-w|-E|-H|-S|-T|...] projects [-a|-f|-n|-p|-r|-u|-w|-E|-H|-I|-S|...] 
   * transactions [-a|-c|-e|-f|-j|-n|-p|-r|-t|-u|-w|-E|-H|-S|-T|...] 

--- a/docs/account-project-management/project-management/project-reports.md
+++ b/docs/account-project-management/project-management/project-reports.md
@@ -51,6 +51,7 @@ A PI or user may appeal a project or account suspension to the ALCF Director by 
 Templates for the quarterly and the EOY reports can be found at the links at the bottom of this page.
 
 Please modify the filename to reflect your project's details: 
+
 - Replace PINAME with the last name of the PI of the INCITE/ALCC project
 - Replace ALLOCATION with INCITE or ALCC 
 - Replace YEAR to the corresponding calendar year

--- a/docs/account-project-management/project-management/starting-alcf-award.md
+++ b/docs/account-project-management/project-management/starting-alcf-award.md
@@ -124,13 +124,17 @@ We have an allocation management tool called sbank, and below are a few helpful 
 - `myquota`: Log into Polaris and type this command to view your home directory quota.
 
 You can use the following command to check your project balance on Polaris:
-- `sbank-list-allocations -p <Project Shortname> -r <system name>`
+
+```bash
+sbank-list-allocations -p <Project Shortname> -r <system name>
+```
 
 For more command examples and details, see [sbank](../allocation-management/sbank-allocation-accounting-system.md).
 
 ## How Can We Help?
 
 We can also help resolve any issues or needs that may be delaying the start of your scientific campaign.
+
 - Are you in need of high-throughput software?
 - Are you having difficulty compiling your application?
 - Does your code have limited restart capabilities?

--- a/docs/ai-testbed/sn40l_inference/using_an_inference_endpoint.md
+++ b/docs/ai-testbed/sn40l_inference/using_an_inference_endpoint.md
@@ -30,7 +30,7 @@ For programmatic access, you can use the API endpoints directly.
 
 #### 1. Setup Your Environment
 
-You can run the following setup from any internet connected machine (your local machine, or an ALCF machine).
+You can run the following setup from any internet-connected machine (e.g. your local machine or an ALCF node).
 
 ```bash
 # Create a new Conda environment
@@ -40,7 +40,8 @@ conda activate globus_env
 # Install necessary packages
 pip install openai globus_sdk
 ```
-Note: A python virtual environment may be used as well.
+
+Note: A Python virtual environment may be used as well:
 ```bash
 virtualenv -p python3.10 globus_env
 source globus_env/bin/activate
@@ -116,9 +117,7 @@ Once authenticated, you can make a test call using cURL or Python.
 !!! tip "Discovering Available Models"
 The endpoint information can be accessed using the [Metis status page](https://metis.alcf.anl.gov/status). It provides the status of the endpoints and the models and the associated configurations.
 
-The list of currently supported chat-completion models on Metis are : 
-- gpt-oss-120b
-- Llama-4-Maverick-17B-128E-Instruct
+The list of currently supported chat-completion models on Metis can be found in [Available Models](../../services/inference-endpoints.md#available-models).
 
 You can programmatically query all available models and endpoints:
 
@@ -127,7 +126,8 @@ You can programmatically query all available models and endpoints:
     curl -X GET "https://inference-api.alcf.anl.gov/resource_server/list-endpoints" \
          -H "Authorization: Bearer ${access_token}" | jq -C '.clusters.metis'
 ```
-If you need any other models to be provisioned via these endpoints, please reach out to support[at]alcf.anl.gov.
+
+If you need any other models to be provisioned via these endpoints, please reach out to [support@alcf.anl.gov](mailto:support@alcf.anl.gov).
 
 See SambaNova's documentation for additional information to supplement the instructions below: [OpenAI compatible API](https://docs.sambanova.ai/sambastudio/latest/open-ai-api.html).
 

--- a/docs/aurora/data-management/daos/daos-overview.md
+++ b/docs/aurora/data-management/daos/daos-overview.md
@@ -3,6 +3,7 @@
 DAOS is a major file system on Aurora, with 230 PB and up to >30 TB/s from 1024 DAOS server storage nodes. DAOS is an open-source, software-defined object store designed for massively distributed non-volatile memory (NVM) and NVMe SSDs. DAOS presents a unified storage model with a native key-array value interface supporting POSIX, MPI-IO, DFS, and HDF5. Users can use DAOS for I/O and checkpointing on Aurora. DAOS is fully integrated with the wider Aurora compute fabric.
 
 This guide covers:
+
 - DAOS pool allocation and container setup
 - POSIX/DFS/MPI-IO access modes
 - Job submission and performance guidance
@@ -679,6 +680,7 @@ users
 ### Large Bulk I/O Write Issue
 
 There is a known Python issue with `pil4dfs`.
+
 - Fix provided in DAOS-17499 
 - Current workaround is to set the `D_IL_COMPATIBLE=1` environment variable.
 - You can skip `pil4dfs` for now if that happens.

--- a/docs/aurora/data-science/frameworks/pyg.md
+++ b/docs/aurora/data-science/frameworks/pyg.md
@@ -5,6 +5,7 @@
 ## PyG on Aurora
 
 PyTorch Geometric includes a base library, called [`torch_geometric`](https://github.com/pyg-team/pytorch_geometric), and a number of optional dependencies:
+
   - [`torch_scatter`](https://github.com/rusty1s/pytorch_scatter)
   - [`torch_sparse`](https://github.com/rusty1s/pytorch_sparse)
   - [`torch_cluster`](https://github.com/rusty1s/pytorch_cluster)

--- a/docs/aurora/performance-tools/vtune.md
+++ b/docs/aurora/performance-tools/vtune.md
@@ -25,6 +25,7 @@ vtune -collect gpu-offload <target>
 ```
 
 This analysis enables you to:
+
 * Identify how effectively your application uses SYCL, OpenMP, or OpenCL kernels and explore them further with GPU Compute/Media Hotspots analysis
 * Analyze execution of Intel Media SDK tasks over time
 * Explore GPU usage and analyze a software queue for GPU engines at each moment of time
@@ -35,11 +36,13 @@ vtune -collect gpu-hotspots <target>
 ```
 
 Use the GPU Compute/Media Hotspots analysis to:
+
 * Explore GPU kernels with high GPU utilization, estimate the effectiveness of this utilization, identify possible reasons for stalls or low occupancy, and options.
 * Explore the performance of your application per selected GPU metrics over time.
 * Analyze the hottest SYCL* standards or OpenCL™ kernels for inefficient kernel code algorithms or incorrect work item configuration.
 
 The GPU Compute/Media Hotspots analysis is a good next step if you have already run the GPU Offload analysis and identified:
+
 * a performance-critical kernel for further analysis and optimization;
 * a performance-critical kernel that is tightly connected with other kernels in the program and may slow down their performance.
 

--- a/docs/polaris/applications-and-libraries/applications/namd.md
+++ b/docs/polaris/applications-and-libraries/applications/namd.md
@@ -11,6 +11,7 @@ ALCF offers assistance with building binaries and compiling instructions for NAM
 ## Running NAMD on Polaris
 
 Prebuilt releases of NAMD binaries can be found in the directory `/soft/applications/namd`. 
+
 * `Linux-x86_64-netlrts-smp-CUDA` supports GPU-resident runs. 
 * `Linux-x86_64-ofi-smp-CUDA` supports general GPU-offload runs.
 * `Linux-x86_64-ofi-smp-CUDA-memopt` supports memory-optimized input files and parallel I/O for the largest simulations (~100 million atoms or more).

--- a/docs/polaris/compiling-and-linking/index.md
+++ b/docs/polaris/compiling-and-linking/index.md
@@ -13,6 +13,7 @@ It is helpful to realize that there is a single `HOME` filesystem for users that
 !!! info
 
     Beginning in CPE 24.11, the NVHPC modules (`PrgEnv-nvhpc`, `nvhpc`, `nvhpc-mixed`) are no longer offered. The NVIDIA modules (`PrgEnv-nvidia`, `nvidia`, `nvidia-mixed`) are now the sole option for modules regarding the NVIDIA programming environment. The move to the NVIDIA modules is to complete the alignment of CPE module flows. The module flow for all environments is as follows:
+
     - Load an environment meta module (e.g. `PrgEnv-nvidia`)
     - Environment meta module loads a compiler (e.g. `nvidia`)
     - User can choose to load a toolkit (`cuda`, `cudatoolkit`)

--- a/docs/polaris/containers/containers.md
+++ b/docs/polaris/containers/containers.md
@@ -38,6 +38,7 @@ Detailed Apptainer documentation is available [here](https://apptainer.org/docs/
 ## Building Containers from Docker or Argonne GitHub Container Registry
 
 Containers can be built by:
+
 - Creating Dockerfiles locally and publishing to DockerHub, then converting to Apptainer.
 - Building directly on ALCF nodes using Apptainer recipe files.
 

--- a/docs/polaris/data-science/frameworks/jax.md
+++ b/docs/polaris/data-science/frameworks/jax.md
@@ -40,6 +40,7 @@ export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1"
 JAX has intrinsic scaling tools to use multiple GPUs on a single node, via the `pmap` function. If this is sufficient for your needs, excellent. If not, another alternative is to use the newer package [mpi4jax](https://github.com/mpi4jax/mpi4jax).
 
 mpi4jax is a relatively new project and requires setting some environment variables for good performance and usability:
+
 - Set `MPI4JAX_USE_CUDA_MPI=1` to use CUDA-Aware MPI, supported in the `conda` module, to do operations directly from the GPU.
 - Set `MPICH_GPU_SUPPORT_ENABLED=1` to use CUDA-Aware MPI.
 

--- a/docs/polaris/performance-tools/NVIDIA-Nsight.md
+++ b/docs/polaris/performance-tools/NVIDIA-Nsight.md
@@ -63,6 +63,7 @@ $ ncu -i {output_filename}.ncu-rep
 #### Post-processing on your local system via GUI
 * Install NVIDIA Nsight Systems and NVIDIA Nsight Compute after downloading both of them from the  [NVIDIA Developer Zone](https://developer.nvidia.com/).
 Remark: Local client version should be the same as or newer than NVIDIA Nsight tools on Polaris.
+
 * Download nsys output files (i.e., ending with .qdrep and . sqlite) to your local system, and then open them with NVIDIA Nsight Systems on your local system.
 * Download ncu output files (i.e., ending with .ncu-rep) to your local system, and then open them with NVIDIA Nsight Compute on your local system.
 

--- a/docs/polaris/system-updates.md
+++ b/docs/polaris/system-updates.md
@@ -94,6 +94,7 @@ The management software on Polaris has been upgraded to HPCM 1.10. The following
          which is consistent with 2.1.2 here in April 2024. Exact version unverified
          against HPE release notes (support-portal gated) -- confirm against the April
          2024 upgrade records if the distinction ever matters. -->
+
 - NVIDIA SDK 23.9
 - NVIDIA driver version 535.154.05
 - CUDA 12.2

--- a/docs/polaris/workflows/parsl.md
+++ b/docs/polaris/workflows/parsl.md
@@ -4,11 +4,11 @@
 > 
 > -- <cite>Parsl Documentation</cite>
 
-For many applications, managing an ensemble of jobs into a workflow is a critical step that can easily become a performance bottleneck. Many tools exist to address this, of which `parsl` is just one. On this page, we'll highlight some of the key pieces of information about `parsl` that are relevant to Polaris. `Parsl` is also [extensively documented](https://parsl.readthedocs.io/en/stable/), has a dedicated Slack channel, and a large community of users and developers beyond ALCF. We encourage you to engage with the `parsl` community for support with `parsl`-specific questions, and for Polaris-specific questions or problems, please contact support@alcf.anl.gov.
+For many applications, managing an ensemble of jobs into a workflow is a critical step that can easily become a performance bottleneck. Many tools exist to address this, of which `parsl` is just one. On this page, we'll highlight some of the key pieces of information about `parsl` that are relevant to Polaris. Parsl is also [extensively documented](https://parsl.readthedocs.io/en/stable/), has a dedicated Slack channel, and a large community of users and developers beyond ALCF. We encourage you to engage with the `parsl` community for support with `parsl`-specific questions, and for Polaris-specific questions or problems, please contact [support@alcf.anl.gov](mailto:support@alcf.anl.gov).
 
 ## Getting Parsl on Polaris
 
-You can install parsl by building off of the ``conda`` modules. You have some flexibility in how you want to extend the ``conda`` module to include parsl, but here is an example way to do it:
+You can install Parsl by building off of the ``conda`` modules. You have some flexibility in how you want to extend the `conda` module to include Parsl, but here is an example way to do it:
 
 ```bash linenums="1"
 # Load the Conda Module (needed every time you use parsl)
@@ -25,7 +25,6 @@ source /path/to/your/virtualenv/bin/activate
 
 # Install parsl (only once)
 pip install parsl
-
 ```
 
 ## Using Parsl on Polaris

--- a/docs/policies/accounts/account-sponsorship-retention-policy.md
+++ b/docs/policies/accounts/account-sponsorship-retention-policy.md
@@ -20,6 +20,7 @@ You are also responsible for approving account renewal requests. When an account
 You are also responsible for approving ANL 593 renewal requests. When an account’s 593 is about to expire, we send a warning notification to the account holder. Among other things, the account holder is asked to contact the approver (the PI of any of the active projects the account holder is associated with) if they wish to renew their 593. We cannot and will not extend someone's 593 without an approval. An important aspect of this process to note is that inaction will result in the account becoming deactivated at the expiration date.
 
 The Project PI/proxy is responsible for the oversight and management of all users associated with the project and for ensuring that such users comply with applicable policies, agreements, and project requirements. Facility policies are listed here: [https://docs.alcf.anl.gov/policies/](https://docs.alcf.anl.gov/policies/)
+
   - Consistent with this responsibility, Project PI/proxy must approve and maintain project user accounts, including renewals and foreign national documentation.
  
 

--- a/docs/policies/queue-scheduling/pullback-policy.md
+++ b/docs/policies/queue-scheduling/pullback-policy.md
@@ -7,10 +7,12 @@ The figures outlined below represent the maximum amount that will be pulled back
 ## INCITE Pullback Policy
 
 On May 1 of the current INCITE calendar year:
+
 - If usage is less than 15%, remove up to 15% of the unused balance.
 - If usage is less than 10%, remove up to 30% of the unused balance.
 
 On September 1 of the current INCITE calendar year:
+
 - If usage is less than 50%, remove up to 33% of the unused balance.
 - If usage is less than 33%, remove up to 50% of the unused balance.
 - If usage is less than 10%, remove up to 75% of the unused balance.

--- a/docs/policies/queue-scheduling/refund-policy.md
+++ b/docs/policies/queue-scheduling/refund-policy.md
@@ -5,6 +5,7 @@ If a system problem affects your run, ALCF will consider a refund of node hours.
 ALCF strongly advises against symlinking between filesystems or hard-coding paths to a different filesystem.
 
 To request a refund, send the following information to [support@alcf.anl.gov](mailto:support@alcf.anl.gov):
+
 - Job ID
 - Machine
 - Reason for refund request

--- a/docs/services/inference-endpoints.md
+++ b/docs/services/inference-endpoints.md
@@ -714,7 +714,9 @@ For large-scale inference, the batch processing service allows you to submit a f
         response = requests.get(url, headers=headers)
         print(response.json())
         ```
+
     **Batch Status Codes:**
+
     - **pending**: The request was submitted, but the job has not started yet.
     - **running**: The job is currently running on a compute node.
     - **failed**: An error occurred; the error message will be displayed when querying the result.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,9 @@ markdown_extensions:
   - md_in_html
   - abbr
   - pymdownx.critic
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.caret


### PR DESCRIPTION
- @memani1, @vksastry, @wcarnold1010 the Metis page listed two out-of-date Chat models; I replaced them with a reference to the ALCF Inference service page's listing of Available Models, which seems more up-to-date
- @bcote-anl your emoji `:tada:` was not rendering correctly