### PR TITLE
Add warning about IRI filesystem operations being restricted to ALCF Sophia users

### DIFF
--- a/docs/services/iri-api.md
+++ b/docs/services/iri-api.md
@@ -352,8 +352,8 @@ This section provides simple examples on how to interface with the API as a star
 
 ### 3. Filesystem
 
-!!! info "Account on Sophia Needed (temporary)"
-    Our current architecture requires users to have an active account on the HPC cluster Sophia to be able to submit filesystem tasks. We are working towards removing this dependency.
+!!! info "Restricted Access (temporary)"
+    Access to filesystem operations is currently restricted to Sophia users. We are working on broadening the access to all ALCF users.
 
 !!! info "Asynchronous Operations"
     All filesystem operations are asynchronous and return a task ID. See [Get a Task](#4-tasks) for how to retrieve your results.

--- a/docs/services/iri-api.md
+++ b/docs/services/iri-api.md
@@ -352,6 +352,9 @@ This section provides simple examples on how to interface with the API as a star
 
 ### 3. Filesystem
 
+!!! info "Account on Sophia Needed (temporary)"
+    Our current architecture requires users to have an active account on the HPC cluster Sophia to be able to submit filesystem tasks. We are working towards removing this dependency.
+
 !!! info "Asynchronous Operations"
     All filesystem operations are asynchronous and return a task ID. See [Get a Task](#4-tasks) for how to retrieve your results.
 


### PR DESCRIPTION
## Description
Adding warning about the Sophia dependency for the IRI API Filesystem component

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
