### PR TITLE
Updating single node benchmark runs

### DIFF
--- a/docs/aurora/node-performance-overview/node-performance-overview.md
+++ b/docs/aurora/node-performance-overview/node-performance-overview.md
@@ -17,18 +17,18 @@ This page aims to give you a high-level overview of key performance numbers for 
 Don't hesitate to contact ALCF staff (via email or Slack) for complaints, bug reports, or praise for these benchmarks.
 
 !!! note
-     These values were measured on Jan. 12th, 2026. The default GPU frequency on Aurora was 1.5 GHz.
+     These values were measured on Aug. 25th, 2026. The default GPU frequency on Aurora was 1.5 GHz.
 
 ## Micro-benchmarks
 
 |                                     |   One Tile |   Full Node | Scaling |
-|-------------------------------------|-----------:|------------:|--------:|
+|                                  ---|-----------:| -----------:|    ----:|
 |         Single Precision Peak Flops | 21 TFlop/s | 252 TFlop/s |    11.8 |
-|         Double Precision Peak Flops | 11 TFlop/s | 127 TFlop/s |    11.9 |
+|         Double Precision Peak Flops | 16 TFlop/s | 190 TFlop/s |    11.8 |
 |            Memory Bandwidth (triad) |     1 TB/s |     12 TB/s |    11.9 |
-| PCIe Unidirectional Bandwidth (H2D) |    54 GB/s |    318 GB/s |     5.9 |
-| PCIe Unidirectional Bandwidth (D2H) |    55 GB/s |    257 GB/s |     4.7 |
-|        PCIe Bidirectional Bandwidth |    76 GB/s |    339 GB/s |     4.5 |
+| PCIe Unidirectional Bandwidth (H2D) |    54 GB/s |    328 GB/s |     6.1 |
+| PCIe Unidirectional Bandwidth (D2H) |    55 GB/s |    264 GB/s |     4.8 |
+|        PCIe Bidirectional Bandwidth |    76 GB/s |    357 GB/s |     4.7 |
 |  Tile2Tile Unidirectional Bandwidth |   185 GB/s |      1 TB/s |     6.0 |
 |   Tile2Tile Bidirectional Bandwidth |   269 GB/s |      2 TB/s |     6.0 |
 |    GPU2GPU Unidirectional Bandwidth |    15 GB/s |     95 GB/s |     6.3 |
@@ -83,12 +83,12 @@ See the source code for this test: [`mpi_sycl_intranode_bw.cpp`](./src/mpi_sycl_
 
 |          |    One Tile |    Full Node | Scaling |
 |       ---| -----------:|  -----------:|    ----:|
-|    DGEMM |  10 TFlop/s |  125 TFlop/s |    11.9 |
+|    DGEMM |  14 TFlop/s |  175 TFlop/s |    12.5 |
 |    SGEMM |  21 TFlop/s |  247 TFlop/s |    12.0 |
-|    HGEMM | 247 TFlop/s | 2469 TFlop/s |    10.0 |
-| BF16GEMM | 256 TFlop/s | 2487 TFlop/s |     9.7 |
-| TF32GEMM | 130 TFlop/s | 1254 TFlop/s |     9.7 |
-|   I8GEMM | 529 TFlop/s | 5128 TFlop/s |     9.7 |
+|    HGEMM | 248 TFlop/s | 2369 TFlop/s |     9.6 |
+| BF16GEMM | 255 TFlop/s | 2454 TFlop/s |     9.6 |
+| TF32GEMM | 125 TFlop/s | 1279 TFlop/s |    10.3 |
+|   I8GEMM | 537 TFlop/s | 5095 TFlop/s |     9.5 |
 
 See the source code for this test: [`gemm.cpp`](./src/gemm.cpp)
 
@@ -97,6 +97,6 @@ See the source code for this test: [`gemm.cpp`](./src/gemm.cpp)
 |                             |   One Tile |  Full Node | Scaling |
 |                          ---|-----------:|-----------:|    ----:|
 | Single-precision FFT C2C 1D |  3 TFlop/s | 36 TFlop/s |    11.6 |
-| Single-precision FFT C2C 2D |  3 TFlop/s | 35 TFlop/s |    10.8 |
+| Single-precision FFT C2C 2D |  3 TFlop/s | 35 TFlop/s |    10.6 |
 
 See the source code for this test: [`fftc2c.cpp`](./src/fftc2c.cpp)

--- a/docs/aurora/node-performance-overview/src/run.sh
+++ b/docs/aurora/node-performance-overview/src/run.sh
@@ -14,9 +14,9 @@ mpirun -n 12 -- ./gpu_tile_compact.sh ./triad
 
 # PCIe Bandwidth
 mpicxx -fsycl pci.cpp -o pci
-mpirun -n 1 --cpu-bind list:1,2,3,4,5,6,52,53,54,55,56,57 -- ./gpu_tile_compact.sh ./pci
-mpirun -n 2 --cpu-bind list:1,2,3,4,5,6,52,53,54,55,56,57 -- ./gpu_tile_compact.sh ./pci
-mpirun -n 12 --cpu-bind list:1,2,3,4,5,6,52,53,54,55,56,57 -- ./gpu_tile_compact.sh ./pci
+mpirun -n 1 --cpu-bind list:1,2,3,4,5,6,53,54,55,56,57,58 -- ./gpu_tile_compact.sh ./pci
+mpirun -n 2 --cpu-bind list:1,2,3,4,5,6,53,54,55,56,57,58 -- ./gpu_tile_compact.sh ./pci
+mpirun -n 12 --cpu-bind list:1,2,3,4,5,6,53,54,55,56,57,58 -- ./gpu_tile_compact.sh ./pci
 
 export MPIR_CVAR_CH4_IPC_GPU_ENGINE_TYPE=copy_high_bandwidth
 mpicxx -fsycl peer2peer.cpp -o peer2peer


### PR DESCRIPTION
## Description
This updates the single-node benchmark runs. The previous numbers were before the 2nd double precision pipeline was on. so this shows the ~ 30% increase in double precision performance from turning it back on.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [x] I have added at least one Label to this PR
