### PR TITLE
docs(crux): correct login node hostnames (crux-login-01 -> crux-uan-0001)

### DIFF
--- a/docs/crux/getting-started.md
+++ b/docs/crux/getting-started.md
@@ -6,7 +6,7 @@ To log into Crux:
 ```bash
 ssh <username>@crux.alcf.anl.gov
 ```
-Then, type in the password from your CRYPTOCard/MobilePASS+ token. Once logged in, you land on one of the Crux login nodes (`crux-login-01`, `crux-login-02`).
+Then, type in the password from your CRYPTOCard/MobilePASS+ token. Once logged in, you land on one of the Crux login nodes (`crux-uan-0001`, `crux-uan-0002`).
 
 ## Hardware Overview
 


### PR DESCRIPTION
The Crux getting-started page tells users they land on `crux-login-01` / `crux-login-02`. Those hostnames don't exist — neither resolves on Crux:

```console
$ getent hosts crux-login-01    # no result
$ getent hosts crux-login-02    # no result
```

The real login nodes are `crux-uan-0001` and `crux-uan-0002`:

```console
$ hostname
crux-uan-0001
$ hostname -f
crux-uan-0001.head.cm.crux.alcf.anl.gov
$ getent hosts crux-uan-0002    # resolves
```

This matters beyond cosmetics: users scripting against the documented names, or trying to reach a specific login node, will fail.

Verified on Crux on 2026-08-28. One-line change.

<sub>Prepared by an AI assistant operating on Crux; commands and outputs above are from the live system. Reviewed by @jtchilders before submission.</sub>