### PR TITLE
Updated colors on buttons to match ALCF palette

### DIFF
--- a/docs/stylesheets/alcf-extra.css
+++ b/docs/stylesheets/alcf-extra.css
@@ -1990,7 +1990,14 @@ pre .normal a {
     transform 125ms;
 }
 
-.md-typeset .alcf-tile-grid ul li > a:hover,
+.md-typeset .alcf-tile-grid ul li > a:hover {
+  border-color: #0061AF;
+  background-color: #E7F6FD;
+  color: #0061AF;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
 .md-typeset .alcf-tile-grid ul li > a:focus-visible {
   border-color: var(--md-accent-fg-color);
   background-color: var(--md-accent-fg-color--transparent);


### PR DESCRIPTION
## Description
Used Claude to update colors on landing page buttons so they match the ALCF branding palette

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [ ] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [ ] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
