### PR TITLE
Add legacy GitLab CI redirect

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ plugins:
   - redirects:
       redirect_maps:
         'support/technical-support.md': 'support/ticket.md'
+        'aurora/services/gitlab-ci.md': 'services/ci/gitlab-ci.md'
         # 'data-management/filesystem-and-storage/file-systems.md': 'data-management/filesystem-and-storage/index.md'
 
 nav:


### PR DESCRIPTION
## Summary
- redirect the legacy Aurora GitLab CI URL to the current services path

## Validation
- venv/bin/mkdocs build --strict --clean --config-file mkdocs.yml