### PR TITLE
fixed broken links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,11 +5,11 @@ The ALCF user-facing documentation source material is hosted on GitHub, in order
 
 <div class="alcf-tile-grid" markdown>
 
-- <a href="support/ticket.md" class="alcf-tile-link"><img src="images/support_agent_80.png" alt="" class="alcf-tile-image"><span>Support Tickets</span></a>
-- <a href="support/get-help/alcf-users-slack.md" class="alcf-tile-link"><img src="images/SLA-Slack.png" alt="" class="alcf-tile-image"><span>ALCF User Slack</span></a>
-- <a href="account-project-management/MyALCF.md" class="alcf-tile-link"><img src="images/myalcf-portal.png" alt="" class="alcf-tile-image"><span>MyALCF</span></a>
+- <a href="support/ticket" class="alcf-tile-link"><img src="images/support_agent_80.png" alt="" class="alcf-tile-image"><span>Support Tickets</span></a>
+- <a href="support/get-help/alcf-users-slack" class="alcf-tile-link"><img src="images/SLA-Slack.png" alt="" class="alcf-tile-image"><span>ALCF User Slack</span></a>
+- <a href="account-project-management/MyALCF" class="alcf-tile-link"><img src="images/myalcf-portal.png" alt="" class="alcf-tile-image"><span>MyALCF</span></a>
 - <a href="https://www.alcf.anl.gov/events" class="alcf-tile-link"><img src="images/event.png" alt="" class="alcf-tile-image"><span>Upcoming Events</span></a>
-- <a href="services/inference-endpoints.md" class="alcf-tile-link"><img src="images/inference.png" alt="" class="alcf-tile-image"><span>Inference</span></a>
+- <a href="services/inference-endpoints" class="alcf-tile-link"><img src="images/inference.png" alt="" class="alcf-tile-image"><span>Inference</span></a>
 - <a href="https://www.alcf.anl.gov/support-center/training" class="alcf-tile-link"><img src="images/video_library.png" alt="" class="alcf-tile-image"><span>Training Videos</span></a>
 
 </div>


### PR DESCRIPTION
## Description
In the main page, many of the links in the get-help section (https://docs.alcf.anl.gov/#get-help) are broken and point to 404 Not-Found. For example, clicking on Inference points to https://docs.alcf.anl.gov/services/inference-endpoints.md, while it should points to https://docs.alcf.anl.gov/services/inference-endpoints. I've confirmed that the links were indeed broken with a dev instance of the ALCF docs running on my MacOS (with Chrome browser).

## Screenshots (if applicable)
<details>
<summary>Before</summary>

<!-- Add your "before" screenshots here via paste and ![]() image link/include syntax -->

</details>

<details>
<summary>After</summary>

<!-- Add your "after" screenshots here -->

</details>

## Related Issue(s)
<!-- If this PR is related to an issue, please link it here, e.g. "#1" -->

KGF: fixes links broken by #1275

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Documentation content update (new page, formatting/typo changes, adding more info, etc.)
- [x] Functionality bug fix
- [ ] New feature (`mkdocs` feature, `mkdocs-material` style changes, HTML/CSS/JS customization, developer or repo tool)

## Checklist
<!-- Please check the items that apply to this PR using "x". -->
- [x] I have run `make serve` or `make build-docs` locally and verified that my changes render correctly
- [ ] I have added at least one Label to this PR
